### PR TITLE
[framework] Integrate GitHub Issues backlog into agent profiles

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,97 @@
+# BACKLOG.md — GitHub Issues-Backed Backlog Pattern
+
+The studio's parked / deferred / "future sprint" work lives as **GitHub Issues** on the project repo, not in chat transcripts, not in scattered TODO markdown files.
+
+## Where the backlog lives
+
+- **Repo:** `brott-studio/battlebrotts-v2` (project-specific — each game repo owns its own backlog)
+- **Filter:** label `backlog` + state `open`
+
+```bash
+gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --state open --limit 100
+```
+
+## Label taxonomy
+
+Every backlog issue carries **three labels**: `backlog` + one `area:*` + one `prio:*`.
+
+**Areas:**
+- `area:audio` — music, SFX, audio mixing
+- `area:art` — sprites, VFX, animation, visual polish
+- `area:ux` — menus, HUD, inputs, onboarding, accessibility
+- `area:gameplay` — mechanics, balance, content, combat, progression
+- `area:tech-debt` — refactors, cleanup, performance, infra hygiene
+- `area:framework` — studio-framework / pipeline / agent-profile work
+
+**Priorities:**
+- `prio:high` — should land in the next 1–2 sprints
+- `prio:mid` — pull in when adjacent or when a sprint is under-scoped
+- `prio:low` — nice-to-have, no ticking clock
+
+## Lifecycle
+
+```
+[open]  ──► [sprint-scoped]  ──►  [PR references issue]  ──►  [merged → auto-closed]
+  │              │                       │                           │
+  │         Ett writes                Nutts writes              GitHub closes
+  │         Closes #N / Refs #N       Closes #N / Refs #N       the issue
+  │         into sprint doc           into PR body              automatically
+  │                                                             on merge to main
+  │
+  └─── or stays open across sprints until priority + capacity align
+```
+
+1. **Open.** Anyone (Riv, The Bott, Ett, Gizmo, HCD) can open an issue when work is deferred.
+2. **Sprint-scoped.** Ett folds issues into the sprint plan during planning (see `agents/ett.md`). Sprint doc references `Closes #N` (full) or `Refs #N` (partial).
+3. **PR.** Nutts/Boltz reference the same issues in the PR body using `Closes #N` / `Refs #N` (see `agents/nutts.md`, `agents/boltz.md`).
+4. **Merge.** GitHub auto-closes `Closes #N` issues on merge to `main`. `Refs #N` stays open for follow-up.
+
+## Who writes issues
+
+**Anyone.** Riv, The Bott, Ett, Gizmo, HCD — whoever is in the conversation where work gets deferred is responsible for opening the issue before the loop closes. This is explicitly called out in `agents/riv.md`.
+
+Chat transcripts are not institutional memory. Issues are.
+
+## How to query
+
+```bash
+# Full open backlog
+gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --state open --limit 100
+
+# High-priority only
+gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --label prio:high --state open
+
+# By area (e.g., for Gizmo's design-phase check)
+gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --label area:gameplay --state open
+
+# As JSON (for Ett's planning preamble)
+gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --state open \
+  --json number,title,labels --limit 100
+
+# Open a new backlog issue
+GH_TOKEN=$(cat ~/.config/gh/brott-studio-token) gh issue create \
+  --repo brott-studio/battlebrotts-v2 \
+  --label backlog --label area:<area> --label prio:<high|mid|low> \
+  --title "<terse title>" --body "<context + acceptance criteria>"
+```
+
+## Compliance
+
+Specc audits every arc retrospective for backlog compliance (see `agents/specc.md`, section 6). Parked work without a matching open issue in `brott-studio/battlebrotts-v2` grades the arc down. It's a compliance gate, not a suggestion.
+
+## Which agents touch the backlog
+
+| Agent   | Interaction                                                            |
+|---------|------------------------------------------------------------------------|
+| Riv     | Opens issues when HCD defers work mid-conversation                     |
+| Ett     | Queries backlog during planning; folds issues into sprint scope        |
+| Gizmo   | Checks backlog by area when writing design specs; references `Refs #N` |
+| Nutts   | Writes `Closes #N` / `Refs #N` in PR bodies                            |
+| Boltz   | Verifies PRs reference backlog issues during review                    |
+| Specc   | Audits arc retrospectives for backlog compliance                       |
+
+## Out of scope (for this pattern)
+
+- GitHub Projects / Milestones — not used; labels + filters are enough.
+- CI workflows enforcing the pattern — Specc's audit is the enforcement mechanism.
+- Cross-repo backlogs — each game repo owns its own backlog. `studio-framework` has no backlog (meta work is tracked via this repo's own issues if needed, not under the `backlog` label pattern).

--- a/agents/boltz.md
+++ b/agents/boltz.md
@@ -36,6 +36,7 @@ For every PR, verify:
 - [ ] Commit messages follow convention `[SN-XXX] type: description`
 - [ ] PR description explains what, why, and how to verify
 - [ ] No unrelated changes bundled in
+- [ ] PR body references backlog issues it addresses: `Closes #N` (full closure, one per line) or `Refs #N` (partial). GitHub auto-links and auto-closes on merge. See [../BACKLOG.md](../BACKLOG.md).
 
 ## GitHub App Auth
 Boltz merges via the Studio Lead Dev GitHub App (APP_ID and key provided in spawn prompt). This is the sole merge mechanism — no one else merges to main.

--- a/agents/ett.md
+++ b/agents/ett.md
@@ -63,6 +63,17 @@ Decision criteria (examples, not exhaustive):
 
 **Step B — planning (only if Step A returned "continue"):**
 
+Before emitting the sprint plan, query the GitHub Issues backlog and fold appropriate items in:
+
+```bash
+gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --state open \
+  --json number,title,labels --limit 100
+```
+
+- Fold at least **1 `prio:high`** item, OR at least **2 `prio:mid`** items, into this sprint's scope — UNLESS you explicitly justify why not (e.g., "S17 is a tech-debt arc, pulling only `area:tech-debt` issues"; "sprint goal is narrow, no backlog fit"). The justification goes in the sprint doc.
+- Reference issue numbers in the sprint plan scope section: `Closes #N` if the sprint fully addresses the issue, `Refs #N` if partial.
+- See [../BACKLOG.md](../BACKLOG.md) for the full backlog pattern.
+
 Emit the unified sprint plan for this iteration, incorporating Gizmo's design input alongside build, infra, testing, and cleanup work.
 
 **Outputs — return one of two things:**

--- a/agents/gizmo.md
+++ b/agents/gizmo.md
@@ -21,6 +21,17 @@ Design input stage of the pipeline. Runs **first** (Phase 1) before sprint plann
 - Define acceptance criteria for features ("how do we know this works?")
 - Provide design input that Ett uses to build the full sprint plan
 
+### Backlog awareness
+When writing a design spec, check the GitHub Issues backlog for a matching open issue (filter by `area:` label — `area:gameplay`, `area:ux`, `area:audio`, `area:art`):
+
+```bash
+gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --label area:gameplay --state open
+```
+
+- If a matching issue exists, reference `Refs #N` in the spec frontmatter or first paragraph.
+- If the design partially/fully addresses a parked item, flag which issues it touches so Ett can write `Closes #N` / `Refs #N` into the sprint plan.
+- See [../BACKLOG.md](../BACKLOG.md) for the backlog pattern.
+
 ## What You Don't Do
 - Write code (that's Nutts)
 - Review PRs (that's Boltz)

--- a/agents/nutts.md
+++ b/agents/nutts.md
@@ -33,9 +33,16 @@ BUILD stage of the pipeline. Writes game code AND tests together.
 - Commits: `[SN-XXX] type: description`
 - Types: `feat`, `fix`, `refactor`, `test`, `docs`
 
+## PR Body Convention — Backlog References
+If the task addresses one or more backlog issues in `brott-studio/battlebrotts-v2`, reference them in the PR body (one per line):
+- `Closes #N` — full closure (GitHub auto-closes the issue on merge)
+- `Refs #N` — partial / related (stays open, GitHub auto-links)
+
+The sprint plan from Ett will tell you which issues the task covers. See [../BACKLOG.md](../BACKLOG.md).
+
 ## Output
 - A PR with clean code + passing tests
-- PR description includes: what changed, why, how to verify
+- PR description includes: what changed, why, how to verify, and `Closes #N` / `Refs #N` for any backlog issues addressed
 
 ## Principles
 - **Code + tests ship together.** No code without tests. No tests without code.

--- a/agents/riv.md
+++ b/agents/riv.md
@@ -16,6 +16,19 @@ Pipeline orchestrator. Spawns agents sequentially, handles review loops, returns
 - By The Bott at the start of each sprint
 - Given: list of tasks, agent assignments, all auth credentials
 
+## Backlog Discipline (Standing Habit)
+
+When HCD (or anyone in a conversation Riv is orchestrating) says **"table this for later"** / **"defer"** / **"park it"** / **"future sprint"** / **"not this sprint"** — Riv (or the agent handling that conversation) MUST open a backlog issue in `brott-studio/battlebrotts-v2` BEFORE closing the loop.
+
+```bash
+GH_TOKEN=$(cat ~/.config/gh/brott-studio-token) gh issue create \
+  --repo brott-studio/battlebrotts-v2 \
+  --label backlog --label area:<area> --label prio:<high|mid|low> \
+  --title "<terse title>" --body "<context + acceptance criteria>"
+```
+
+Chat transcripts are not institutional memory. Issues are. See [../BACKLOG.md](../BACKLOG.md).
+
 ## Pipeline Execution
 
 ```

--- a/agents/specc.md
+++ b/agents/specc.md
@@ -64,6 +64,16 @@ In addition to git/PR/code review, use these OpenClaw system tools:
 - Are agents referencing KB entries? (check if known problems recur)
 - Flag stale or missing entries
 
+### 6. Backlog Compliance Audit (Standing Directive, Compliance Gate)
+**Verify every "deferred" / "parked" / "future sprint" item called out in the arc has a matching open backlog issue in `brott-studio/battlebrotts-v2`.**
+
+- Cross-check arc retrospectives and sprint docs against:
+  ```bash
+  gh issue list --repo brott-studio/battlebrotts-v2 --label backlog --state open --limit 200
+  ```
+- If parked work is listed without an issue number (or the referenced issue doesn't exist / is closed without resolution), that's a compliance miss. **Grade the arc down.**
+- This is a compliance gate — chat transcripts don't count as institutional memory; GitHub Issues do. See [../BACKLOG.md](../BACKLOG.md).
+
 ## What You Don't Do
 - Write game code
 - Review PRs (that's Boltz)


### PR DESCRIPTION
Wires the HCD-approved GitHub-Issues-backed backlog pattern into the studio pipeline so S17 and onward use issue tracking natively. Backlog lives in `brott-studio/battlebrotts-v2` (31 issues seeded: #94–#124, labels `backlog` + `area:*` + `prio:*`).

## Files changed

| File | Summary |
|------|---------|
| `agents/ett.md` | Planning preamble: query open backlog; fold ≥1 `prio:high` or ≥2 `prio:mid` per sprint (or justify); reference `Closes #N` / `Refs #N` in sprint docs. |
| `agents/gizmo.md` | Design phase: check backlog filtered by `area:*`; reference `Refs #N` in spec frontmatter when a matching issue exists. |
| `agents/specc.md` | Arc-rollup audit: compliance gate — every deferred/parked item must have a matching open backlog issue; grade down if missing. |
| `agents/riv.md` | Orchestrator habit: when HCD defers / tables / parks work, open a backlog issue BEFORE closing the loop (chat transcripts are not institutional memory). |
| `agents/boltz.md` | Review checklist: verify PR body references backlog issues with `Closes #N` / `Refs #N`. |
| `agents/nutts.md` | PR body convention: `Closes #N` (full) / `Refs #N` (partial), one per line. |
| `BACKLOG.md` (new) | Canonical doc for the pattern — location, label taxonomy, lifecycle, ownership, query examples, agent interaction matrix. |

Total: 7 files, ~150 LOC added.

## Constraints honored
- Doc-only. No code, no workflow files, no pipeline logic changes.
- Surgical edits — added sections/lines, did not restructure existing profiles.
- Did not touch `FRAMEWORK.md` / `PIPELINE.md` (canon-debate scope).
- No GitHub Projects / Milestones / CI added.
- `battlebrotts-v2` issues untouched.

## Ready for Boltz review.
