### PR TITLE
framework: introduce arc/sprint vocabulary + ARC_BRIEF.md + arc-intent check

### DIFF
--- a/ARC_BRIEF.md
+++ b/ARC_BRIEF.md
@@ -1,0 +1,183 @@
+# Arc Brief — The Canonical Pattern
+
+> **An arc is the outer strategic unit HCD directs. A sprint is one iteration
+> of the pipeline. An arc contains one or more sprints and ends when Gizmo
+> and Ett converge on "done."**
+
+This doc describes what an arc brief is, how to write one, and why. It's the
+canonical reference for the arc-level direction HCD hands to The Bott, which
+The Bott then hands to Riv at arc kickoff.
+
+---
+
+## What an Arc Is
+
+An **arc** is a strategic or creative goal that may take one or several
+pipeline iterations to realize. Examples:
+
+- "Make the first 5 minutes of play irresistible."
+- "Clean up tech debt and get all infrastructure healthy."
+- "Get combat feeling weighty."
+- "Ship a shop loop HCD can play end-to-end."
+
+An arc has **direction, not destination**. HCD points at a place and gives a
+budget. The pipeline discovers what "there" actually looks like along the way.
+
+An arc ends when the **inner loop** (Gizmo + Ett) converges on "the arc's
+intent is satisfied and no high-value work remains." Not when a checklist is
+ticked.
+
+A **sprint** is one full pipeline iteration inside an arc:
+Gizmo → Ett → Nutts → Boltz → Optic → Specc → audit commit.
+Sprints within an arc are numbered `N.1`, `N.2`, `N.3`, where `N` is the
+arc number.
+
+---
+
+## What Belongs in an Arc Brief
+
+Short. Vision-led for creative arcs, systems-led for infra arcs. Speak the
+language of the problem.
+
+**Always:**
+
+1. **Arc goal** — one or two lines, stated in terms of intent, not acceptance
+   criteria. Creative arcs: a felt outcome ("new player thinks *wow this
+   looks cool*"). Infra arcs: a health description ("CI green on main,
+   test suite covers all sprints explicitly").
+2. **Priorities** — 2–6 bullets in the language of the problem. For creative
+   arcs, evocative: "Circle, circle, COMMIT — boxing rhythm, not orbit-and-
+   miss." For infra arcs, concrete: "Replace shared-PAT workaround with
+   per-agent GitHub Apps."
+3. **Max sprints** — a *fuse*, not a target. "Escalate after 5 sprints."
+   The loop should converge before this; the fuse exists so a stuck arc
+   surfaces to HCD instead of spinning forever.
+
+**Sometimes:**
+
+4. **Hard constraints** — scope fences. "No behavior changes to
+   `combat_sim.gd`." "No new external dependencies." Only include when a
+   real constraint exists; don't invent them for insurance.
+5. **Context carry-over** — one or two sentences of state HCD wants the
+   arc to start from. Prior arc outcomes, known blockers, relevant recent
+   commits.
+
+**Never (these are anti-patterns in arc briefs):**
+
+- **Acceptance criteria as a checklist.** Arc completion is a judgment
+  call by Gizmo+Ett. A checklist collapses that judgment into mechanics
+  and drives the loop toward ticking items instead of satisfying intent.
+  *Exception:* pure infra arcs may state binary success conditions ("all
+  CI workflows green on main") because intent *is* the condition for
+  that arc type. Even then: 1–2 conditions, not a 10-item checklist.
+- **Pre-planned sprints.** Don't say "S16.1 will do X, S16.2 will do Y."
+  That's Ett's job. Arc briefs describe intent; sprint plans describe
+  execution. If you find yourself sketching sprints, stop — write it
+  as a priority bullet and trust Ett to sequence.
+- **Re-explaining pipeline mechanics.** Riv, Ett, and every agent read
+  FRAMEWORK.md and PIPELINE.md every spawn. Don't repeat those rules
+  in the brief.
+- **Task lists.** Tasks belong in sprint plans.
+
+---
+
+## Where the Arc Brief Lives
+
+**File:** `<project-repo>/arcs/arc-<N>.md`
+
+**Delivery to Riv:** The arc brief is passed into Riv's spawn prompt. Two
+acceptable patterns:
+
+- **Inline:** the arc brief contents pasted directly into the Riv spawn
+  prompt. Good for short briefs.
+- **By reference + summary:** the spawn prompt contains a one-sentence
+  quote of the arc goal plus a pointer to `arcs/arc-<N>.md` for the full
+  brief. Good for richer briefs. The essential intent is always mirrored
+  in the spawn prompt, not left to the file alone.
+
+Riv passes the arc brief (or pointer) forward to Gizmo and Ett every sprint
+in the arc, so the arc-intent check has the vision to evaluate against.
+
+---
+
+## The Successful S13 Example
+
+The S13 arc was "Make the First 5 Minutes Irresistible" — five sprints
+ran autonomously, and the era is the reference point for what arc-style
+direction looks like done well. Reproduced below as a worked example:
+
+> **Creative Direction: "Make the First 5 Minutes Irresistible"**
+>
+> *A new player should feel: exciting fight (punches land!) → cool shop
+> (ooh shiny!) → one fun BrottBrain choice → back to fighting. Fast,
+> visual, rewarding. Depth reveals itself after the hook.*
+>
+> **Design priorities for Gizmo:**
+>
+> 1. **Combat rhythm** — "Circle, circle, COMMIT." Right now bots orbit
+>    and miss too much. Needs tension → impact → tension cycles.
+> 2. **Shop as visual experience** — Player should think "WOW this looks
+>    cool — what does it do?" NOT "let me study these stats."
+> 3. **BrottBrain early taste** — Introduce ONE simple exciting choice.
+>    Appetizer, not full menu.
+> 4. **Audio design vision** — Design how charming Wall-E robots should
+>    SOUND. Don't pick tools yet.
+>
+> **Infrastructure:**
+> - Merge Specc KB PR #53
+> - Re-run fun evaluation Spike (match logging now exists)
+>
+> **Max sprints:** 10
+
+Notice what's there: vision, priorities in problem-language (creative for
+Gizmo, list for infra), a fuse. Notice what's absent: acceptance criteria,
+pre-planned sprints, task lists, pipeline mechanics.
+
+---
+
+## Arc Completion
+
+An arc ends when **Gizmo reports arc-intent satisfied** AND **Ett decides
+no remaining work is worth another sprint.** This is a judgment, not a test.
+
+Gizmo, at each sprint's Phase 1, emits an **arc-intent check** (in addition
+to the standard GDD drift check):
+
+- **Arc intent satisfied** — the arc's goal reads as met. Ett decides
+  completion.
+- **Progressing — [what's still missing]** — arc work remains.
+- **Drift from arc intent: [what]** — prior sprint pulled away from the
+  goal; the next sprint should correct.
+
+Ett, at each sprint's Phase 2 Step A, folds Gizmo's arc-intent check into
+the continue-or-complete decision alongside the prior audit grade, the
+remaining backlog for the arc, and the max-sprint fuse. See `agents/ett.md`
+and `agents/gizmo.md` for the exact mechanics.
+
+---
+
+## When You're About to Write Acceptance Criteria…
+
+…stop and ask: "Is this a real intent condition, or am I smuggling a plan
+into the brief?"
+
+- *"CI green on main and on a PR"* for a pure-infra arc → acceptable, it's
+  intent.
+- *"test_runner.gd enumerates all sprint files explicitly"* → that's
+  a plan step. It belongs in Ett's sprint plan, not the arc brief.
+
+When in doubt, leave it out. Trust Ett to discover the work.
+
+---
+
+## Summary (the whole thing on one page)
+
+- **Arc** = strategic unit, HCD directs, Gizmo+Ett judge "done."
+- **Sprint** = one pipeline iteration, Ett plans, pipeline executes, Specc
+  audits.
+- **Arc brief** = goal + priorities + fuse. Short. No acceptance checklist.
+  No pre-planned sprints. No pipeline mechanics.
+- **Completion** = Gizmo "arc intent satisfied" + Ett "no more meaningful
+  work."
+
+That's the whole pattern.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -24,7 +24,7 @@ Examples:
 
 Rules:
 - Lowercase, kebab-case
-- Sprint ID first if applicable (`sprint-N` or `sprint-N.M` for sub-sprints)
+- Sprint/arc ID first if applicable (`arc-N` for arcs, `sprint-N.M` for sprints within an arc)
 - Short slug describing the work (3–5 words max)
 - No personal names in branches
 
@@ -99,7 +99,7 @@ Ett assigns task IDs in the sprint plan. Agents reference them in PR titles, com
 When using git worktrees for parallel work:
 ```
 /tmp/<repo-name>/                     — main clone
-/tmp/<repo-name>-sprint-<N.M>/        — worktree for a specific sub-sprint
+/tmp/<repo-name>-sprint-<N.M>/        — worktree for a specific sprint
 /tmp/<repo-name>-scratch/             — throwaway exploration
 ```
 

--- a/ESCALATION.md
+++ b/ESCALATION.md
@@ -10,7 +10,7 @@ How the studio lead (Riv) and any orchestrator should decide when to proceed aut
 
 - Defensible trade-offs where 2+ reviewers align (e.g., Boltz + Nutts both approve)
 - Bug fixes, test changes, refactors that fit the sprint brief
-- Sub-sprint transitions within an approved arc
+- Sprint transitions within an approved arc
 - Scope interpretation inside the creative brief's boundaries
 - Any decision where Gizmo has design authority and has made a call
 - Process/tooling improvements that serve the existing brief
@@ -54,7 +54,7 @@ How the studio lead (Riv) and any orchestrator should decide when to proceed aut
 ## Anti-patterns (don't do these)
 
 - Asking the Human Creative Director to pick between two options the team can pick between themselves.
-- Pausing sub-sprints waiting for the Human Creative Director to "greenlight" something the arc brief already approved.
+- Pausing sprints waiting for the Human Creative Director to "greenlight" something the arc brief already approved.
 - Relaying every reviewer nit up the chain — nits are the team's job to resolve.
 - Escalating to look cautious when the data clearly supports proceeding.
 

--- a/FRAMEWORK.md
+++ b/FRAMEWORK.md
@@ -43,15 +43,15 @@ These four rules appear here AND inline in every agent profile so they're load-b
 
 ```
 🎬 Human Creative Director (HCD)
-   Direction, feel, playtesting, final say
+   Direction, feel, playtesting, final say. Writes the arc brief.
 
 🤖 The Bott — Executive Producer
-   Pipeline design, sprint planning, orchestration, framework maintenance
-   Spawns Riv per sprint. Intervenes on exceptions.
+   Pipeline design, arc framing, orchestration kickoff, framework maintenance.
+   Spawns Riv per arc. Intervenes on exceptions.
 
 📋 Riv — Lead Orchestrator
-   Executes the sprint pipeline, manages review loops and sub-sprint transitions.
-   Spawned by The Bott per sprint.
+   Executes the sprint loop inside an arc, manages review loops and sprint transitions.
+   Spawned by The Bott per arc.
 
 🕵️ Specc — Inspector (independent)
    Post-sprint audits, learning extraction, KB maintenance.
@@ -85,36 +85,45 @@ Rivett was the original combined PM + orchestrator role. Initially retired becau
 
 ---
 
+## The Arc + Sprint Model
+
+The framework has two container levels:
+
+- **Arc** — the outer, strategic unit HCD directs. An arc has a goal ("make the first 5 minutes irresistible", "get infra healthy") but not an acceptance checklist. It ends when Gizmo and Ett converge on "arc intent satisfied and no high-value work remains." HCD delivers an **arc brief** — see [ARC_BRIEF.md](ARC_BRIEF.md) for the canonical pattern.
+- **Sprint** — one full pipeline iteration inside an arc. Gizmo → Ett → Nutts → Boltz → Optic → Specc. Ships code + audit. Sprints within an arc are numbered `N.1`, `N.2`, `N.3`, where `N` is the arc number.
+
+Riv is spawned per **arc**. Inside the arc, Riv runs the sprint loop until Ett emits an arc-complete marker.
+
 ## Sprint Pipeline
 
 Full flow detail: [PIPELINE.md](PIPELINE.md).
 
 ```
-The Bott → spawns Riv with sprint goal
+The Bott → spawns Riv with arc brief
   │
-  Riv sub-sprint loop:
+  Riv sprint loop:
   │
-  ├─ [Top of iteration] Audit-gate: verify prior Specc audit exists (skip on first iteration)
-  ├─ Gizmo (Design Input) → no-drift / spec-delta / scope-rethink
+  ├─ [Top of sprint] Audit-gate: verify prior Specc audit exists (skip on first sprint of arc)
+  ├─ Gizmo (Design Input + Arc-Intent Check) → no-drift / spec-delta / scope-rethink; arc-intent verdict
   ├─ Ett (Plan + Continuation-check):
-  │    ├─ Complete → EXIT LOOP
+  │    ├─ Complete (arc intent satisfied) → EXIT LOOP
   │    └─ Continue → emit plan (incorporates Gizmo output)
   ├─ Nutts (Build) → PR
   ├─ Boltz (Review) → approve/merge or request changes → loop to Nutts
   ├─ Optic (Verify) → PASS/FAIL report (never escalates)
   ├─ Specc (Audit) → commits to studio-audits + KB
-  └─ loop back to top of iteration
+  └─ loop back to top of next sprint
   │
-  Riv → final report → The Bott
+  Riv → final arc report → The Bott
 ```
 
 ### Pipeline Rules
 - Each stage reads the previous stage's output. No stage skipping.
-- **Sub-sprint loop-precondition gate [Compliance-reliant, hard rule]:** At the top of each sub-sprint iteration (skip on the very first), Riv verifies the prior Specc audit is committed to `studio-audits` before spawning Gizmo. If missing → STOP and escalate. Ett then, as the first action of its single per-iteration spawn, performs the continue-or-complete check before emitting the plan. Riv is mechanical orchestration; it does not self-decide continuation. The Bott monitors the gate independently.
+- **Sprint loop-precondition gate [Compliance-reliant, hard rule]:** At the top of each sprint in an arc (skip on the very first), Riv verifies the prior Specc audit is committed to `studio-audits` before spawning Gizmo. If missing → STOP and escalate. Ett then, as the first action of its single per-sprint spawn, performs the continue-or-complete check before emitting the plan. Riv is mechanical orchestration; it does not self-decide continuation. The Bott monitors the gate independently.
 - If VERIFY fails → back to BUILD (not "ship anyway")
 - If REVIEW requests changes → back to BUILD (not "merge anyway")
 - Riv escalates to The Bott per [ESCALATION.md](ESCALATION.md) 🔴/🚨 criteria.
-- Pipeline state lives in a sprint file, not in any agent's memory.
+- Pipeline state lives in sprint plan files + the arc brief, not in any agent's memory.
 
 ---
 
@@ -232,7 +241,7 @@ Every rule in this framework is tagged **[Structural]** or **[Compliance-reliant
 | Visual verification | Playwright in pipeline | [Structural] |
 | Agent logging | Git history IS the log (no separate log files needed) | [Structural] |
 | Dashboard freshness | Generated after sprint, not maintained live | [Structural] |
-| Sub-sprint Specc gate | Riv + Ett + The Bott all check | [Compliance-reliant] |
+| Sprint Specc gate | Riv + Ett + The Bott all check | [Compliance-reliant] |
 | Role boundaries | Pipeline stages (agents only do their stage) | [Compliance-reliant] |
 | Secrets handling | PAT in file, credential helper | [Compliance-reliant] (file-based, not CI-gated) |
 | Comms routing | Channel not DM | [Compliance-reliant] |

--- a/ORCHESTRATION_PATTERNS.md
+++ b/ORCHESTRATION_PATTERNS.md
@@ -142,11 +142,11 @@ The Bott → Riv (orchestrator) → Gizmo → Ett → Nutts → Boltz → Optic 
 Riv → Nutts → Boltz → [comments?] → Nutts fix → Boltz re-review → Optic → Specc
 ```
 
-**Hard gate between sub-sprints (compliance-reliant):**
+**Hard gate between sprints (compliance-reliant):**
 ```
 Riv → ...sprint-N pipeline... → Specc audit committed → GATE → Riv starts sprint-N+1
 ```
-Before sub-sprint N+1 begins, Riv MUST verify `audits/<project>/sprint-<N>.md` exists in `brott-studio/studio-audits`. See [PIPELINE.md](PIPELINE.md) "Sub-Sprint Audit Gate" and [SPAWN_PROTOCOL.md](SPAWN_PROTOCOL.md) Riv template.
+Before sprint N.M+1 begins, Riv MUST verify `audits/<project>/sprint-<N.M>.md` exists in `brott-studio/studio-audits`. See [PIPELINE.md](PIPELINE.md) "Sprint Audit Gate" and [SPAWN_PROTOCOL.md](SPAWN_PROTOCOL.md) Riv template.
 
 **Incremental-write protocol for subagent tasks:**
 All spawned subagent tasks should use the skeleton-first + save-after-each-section pattern from [SUBAGENT_PLAYBOOK.md](SUBAGENT_PLAYBOOK.md). This ensures partial progress survives runtime cut-offs. Particularly important for research and writing tasks.

--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -1,29 +1,37 @@
 # Pipeline & Roles
 
+## The Arc + Sprint Model
+
+- **Arc** = the outer strategic unit. HCD delivers an [arc brief](ARC_BRIEF.md); Gizmo + Ett decide when it's complete.
+- **Sprint** = one full pipeline iteration inside an arc. Numbered `N.1`, `N.2`, … where `N` is the arc number.
+
+Riv is spawned per arc. Inside the arc, Riv runs the sprint loop until Ett emits the arc-complete marker.
+
 ## Sprint Pipeline (Orchestrated by Riv)
 
 ```
-The Bott (EP) → spawns Riv with sprint tasks
+The Bott (EP) → spawns Riv with arc brief
   │
-  Riv (Lead Orchestrator) → sub-sprint loop:
+  Riv (Lead Orchestrator) → sprint loop:
   │
   ├─ Phase 0: AUDIT-GATE (loop precondition)
-  │    └─ Skipped on the first iteration. Otherwise: verify prior Specc audit
+  │    └─ Skipped on the first sprint of the arc. Otherwise: verify prior Specc audit
   │       exists in `brott-studio/studio-audits`. Missing → STOP, escalate to The Bott.
   │
-  ├─ Phase 1: DESIGN INPUT
-  │    └─ GIZMO (Design Review) — always runs first
+  ├─ Phase 1: DESIGN INPUT + ARC-INTENT CHECK
+  │    └─ GIZMO — always runs first
   │         └─ Reviews game state against GDD
+  │         └─ Emits arc-intent verdict (satisfied / progressing / drift) when arc brief provided
   │         └─ If design changes → provides spec + GDD update
   │         └─ If no changes → "No design drift, proceed"
-  │         └─ If DRIFT DETECTED → escalate to The Bott
+  │         └─ If GDD DRIFT DETECTED → escalate to The Bott
   │         └─ Output goes to ETT
   │
   ├─ Phase 2: CONTINUATION-CHECK + SPRINT PLANNING
-  │    └─ ETT (Technical PM) — single spawn per iteration
-  │         └─ Inputs: Gizmo's output + prior Specc audit (if any) + backlog + HCD escalations
+  │    └─ ETT (Technical PM) — single spawn per sprint
+  │         └─ Inputs: Arc brief + Gizmo's output (incl. arc-intent verdict) + prior Specc audit (if any) + backlog + HCD escalations
   │         └─ Step A — continue-or-complete check:
-  │              • Complete → emit sprint-complete marker → Riv EXITS loop → REPORT
+  │              • Complete → emit arc-complete marker → Riv EXITS loop → REPORT
   │              • Continue → fall through to Step B
   │         └─ Step B — emit unified sprint plan (design + build + infra + cleanup)
   │
@@ -33,34 +41,34 @@ The Bott (EP) → spawns Riv with sprint tasks
   │    │    └─ If changes needed → NUTTS (Fix) → BOLTZ (Re-review)
   │    │    └─ If rejected twice → escalate to The Bott
   │    ├─ OPTIC (Verify) → tests + Playwright + sims + vision
-  │    │    └─ If FAIL → note failure in sprint results; continue to Specc. Ett addresses in next sub-sprint.
+  │    │    └─ If FAIL → note failure in sprint results; continue to Specc. Ett addresses in the next sprint.
   │    └─ SPECC (Audit) → audit + KB entries (commits to `studio-audits`)
   │
   └─ loop back to Phase 0 (audit-gate → Gizmo → Ett …)
 
-REPORT → Riv → The Bott (fires only when Ett's Phase 2 Step A returns "complete")
+REPORT → Riv → The Bott (fires only when Ett's Phase 2 Step A returns the arc-complete marker)
 ```
 
 ## Continuation-Check + Planning (Phase 2)
 
-**[Compliance-reliant.]** Ett is spawned exactly once per sub-sprint iteration, immediately after Gizmo. Ett's first action is the continue-or-complete check; if continuing, Ett emits the sprint plan that incorporates Gizmo's design input. Riv does not self-decide continue-vs-complete — that's Ett's call.
+**[Compliance-reliant.]** Ett is spawned exactly once per sprint, immediately after Gizmo. Ett's first action is the continue-or-complete check; if continuing, Ett emits the sprint plan that incorporates Gizmo's design input. Riv does not self-decide continue-vs-complete — that's Ett's call.
 
 **Ett's inputs (every spawn):**
-- Gizmo's design assessment (spec-delta, scope-rethink, or "no drift")
-- The prior Specc audit report (or "first iteration, no audit yet")
-- The active sprint plan / sprint goal from The Bott
-- The current backlog
-- Any HCD escalations surfaced since the sprint started
+- The arc brief (goal, priorities, max-sprints fuse, hard constraints)
+- Gizmo's design assessment (spec-delta, scope-rethink, or "no drift") **and** arc-intent verdict when arc context is provided
+- The prior Specc audit report (or "first sprint in arc, no audit yet")
+- The current backlog (including carry-forward from the arc's prior sprints)
+- Any HCD escalations surfaced since the arc started
 
 **Ett's outputs — one of two things:**
-- **(a) Sprint plan** (continue) — the plan for this iteration's execution phase (design tasks + build + infra + cleanup), incorporating Gizmo's output. Riv proceeds to Nutts.
-- **(b) Sprint-complete marker** (complete) — explicit "sprint has converged" signal with one-line rationale. Riv exits the loop and produces its final report to The Bott.
+- **(a) Sprint plan** (continue) — the plan for this sprint's execution phase (design tasks + build + infra + cleanup), incorporating Gizmo's output. Riv proceeds to Nutts.
+- **(b) Arc-complete marker** (complete) — explicit "the arc has converged" signal with one-line rationale (citing Gizmo's arc-intent verdict, audit trend, or fuse). Riv exits the loop and produces its final report to The Bott.
 
 Do not return both. Do not leave the decision implicit.
 
-Riv's final report to The Bott fires on **sprint-complete**, not on audit-commit.
+Riv's final report to The Bott fires on **arc-complete**, not on audit-commit.
 
-**Final-iteration trade-off:** On the iteration where Ett decides "complete," Gizmo still ran (Phase 1 precedes Phase 2). This is accepted: the wasted-spawn cost is trivial and Gizmo's final-state design assessment becomes useful audit context for The Bott and for Specc retrospectives.
+**Last-sprint trade-off:** On the sprint where Ett decides "complete," Gizmo still ran (Phase 1 precedes Phase 2). This is accepted: the wasted-spawn cost is trivial and Gizmo's final-state design assessment becomes useful audit context for The Bott and for Specc retrospectives.
 
 ## Roles
 
@@ -103,16 +111,16 @@ See [COMMS.md](COMMS.md) for full rules.
 - The Bott is the sole channel voice. For every Riv completion, The Bott posts a curated summary to the channel.
 - HCD gets @-mentioned (via The Bott's channel post) only for: playtest-ready builds, merge calls needing HCD signoff, or escalations per [ESCALATION.md](ESCALATION.md) 🔴/🚨 criteria
 
-## Sub-Sprint Audit Gate (HARD RULE)
+## Sprint Audit Gate (HARD RULE)
 
-**[Compliance-reliant.]** At the top of each sub-sprint iteration (skipped on the first), the prior Specc audit MUST exist in `brott-studio/studio-audits` at `audits/<project>/sprint-<N>.md` before any agent for sub-sprint N+1 is spawned. This gate is a **loop precondition**, not a post-Specc check — its natural home is at the start of each iteration.
+**[Compliance-reliant.]** At the top of each sprint in an arc (skipped on the very first sprint of the arc), the prior Specc audit MUST exist in `brott-studio/studio-audits` at `audits/<project>/sprint-<N.M>.md` before any agent for sprint N.M+1 is spawned. This gate is a **loop precondition**, not a post-Specc check — its natural home is at the start of each sprint.
 
 Redundant compliance surfaces:
-- **Riv** verifies via `gh api` check at the top of each iteration (Phase 0) before spawning Gizmo. If missing, STOP and escalate to The Bott.
+- **Riv** verifies via `gh api` check at the top of each sprint (Phase 0) before spawning Gizmo. If missing, STOP and escalate to The Bott.
 - **Ett** re-verifies during its Step A continuation check; refuses to plan without prior audit data.
-- **The Bott** monitors for sub-sprint transitions without matching audit commit and intervenes.
+- **The Bott** monitors for sprint transitions without matching audit commit and intervenes.
 
-Specc has been invaluable to pipeline quality. Skipping Specc between sub-sprints has caused real problems — this gate exists because of that history.
+Specc has been invaluable to pipeline quality. Skipping Specc between sprints has caused real problems — this gate exists because of that history.
 
 ## Pipeline Completion Rule
 
@@ -121,6 +129,7 @@ Never notify HCD for playtesting until the FULL pipeline has completed (Design �
 ## Cross-references
 
 - Full framework: [FRAMEWORK.md](FRAMEWORK.md)
+- Arc brief pattern: [ARC_BRIEF.md](ARC_BRIEF.md)
 - Per-agent spawn templates: [SPAWN_PROTOCOL.md](SPAWN_PROTOCOL.md)
 - Subagent knobs & incremental-write protocol: [SUBAGENT_PLAYBOOK.md](SUBAGENT_PLAYBOOK.md)
 - Escalation tiers: [ESCALATION.md](ESCALATION.md)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ If you're a fresh agent session spawned against this repo, read the framework in
 | File | Purpose |
 |---|---|
 | [FRAMEWORK.md](FRAMEWORK.md) | Studio operating manual — principles, leadership, pipeline, core rules |
-| [PIPELINE.md](PIPELINE.md) | Sprint flow, phases, orchestration, sub-sprint Specc gate |
+| [PIPELINE.md](PIPELINE.md) | Sprint flow, phases, orchestration, sprint Specc gate |
+| [ARC_BRIEF.md](ARC_BRIEF.md) | Arc brief pattern — what HCD writes to direct an arc |
 | [SPAWN_PROTOCOL.md](SPAWN_PROTOCOL.md) | Per-agent spawn templates, preamble, credential handling |
 | [ORCHESTRATION_PATTERNS.md](ORCHESTRATION_PATTERNS.md) | Multi-agent patterns (pipeline, fan-out, spike sprint) |
 | [SUBAGENT_PLAYBOOK.md](SUBAGENT_PLAYBOOK.md) | Spawn knobs (thinking, timeout), incremental-write protocol |

--- a/REPO_MAP.md
+++ b/REPO_MAP.md
@@ -54,7 +54,7 @@ The three-repo architecture of the brott-studio AI agent studio.
 **Why separate from the project repo:**
 1. **Independence.** An audit critical of the build must live somewhere the builders don't own. Separate repo = separate merge rights.
 2. **Cross-sprint history.** Audits persist as the project evolves. If the game repo gets force-pushed or squashed, audit history remains intact.
-3. **Structural enforcement surface** (aspirational). A future structural gate could watch `studio-audits` commits to unlock `<project-repo>` sprint-N+1 merges. See [ESCALATION.md](ESCALATION.md) context on sub-sprint Specc gate.
+3. **Structural enforcement surface** (aspirational). A future structural gate could watch `studio-audits` commits to unlock `<project-repo>` arc-N+1 merges. See [ESCALATION.md](ESCALATION.md) context on the sprint Specc gate.
 
 ---
 

--- a/SPAWN_PROTOCOL.md
+++ b/SPAWN_PROTOCOL.md
@@ -45,12 +45,18 @@ You are Gizmo, Game Designer for <project>.
 
 Your task: <design task>.
 
+If an arc brief is provided, also emit an arc-intent verdict per your profile:
+  - `Arc intent: satisfied`
+  - `Arc intent: progressing — [what's still missing]`
+  - `Arc intent: drift — [what]`
+
 Deliverables:
 - Design spec in <project>/specs/<short-slug>.md, OR
 - GDD updates if the task is a GDD revision, OR
 - "No design drift, proceed" if reviewing game state.
+- Arc-intent verdict (when arc context provided).
 
-If design drift detected that changes scope or tone → escalate to Riv
+If GDD drift detected that changes scope or tone → escalate to Riv
 (🔴 per ESCALATION.md).
 ```
 
@@ -61,18 +67,23 @@ You are Ett, Technical PM for <project>.
 
 [preamble]
 
-Your task: plan sprint-<N> (or sub-sprint <N.M>).
+Your task: continuation-check + planning for arc-<N>, sprint <N.M>.
 
-Required reads before planning:
-- Gizmo's latest design output (if applicable)
-- Specc's audit for sprint-<N-1> (or sub-sprint <N.M-1>) — REQUIRED.
+Required reads before deciding:
+- Arc brief at <project>/arcs/arc-<N>.md (or inline in this prompt)
+- Gizmo's latest design output + arc-intent verdict
+- Specc's audit for sprint-<N.M-1> — REQUIRED (unless first sprint in arc).
   Audit lives at: brott-studio/studio-audits → audits/<project>/sprint-<prev>.md
   If missing, FLAG and escalate to Riv before proceeding.
 - Backlog / current issues in <project-repo>
 - Infra needs (ask Patch if uncertain)
 
-Deliverable: sprint plan at <project>/sprints/sprint-<N>.md.
-Include: goals, task breakdown with [SN-XXX] IDs, acceptance criteria,
+Step A — continue-or-complete check first. If complete, emit arc-complete
+marker and stop (no plan).
+
+Step B (if continuing) — deliverable: sprint plan at
+<project>/sprints/sprint-<N.M>.md.
+Include: goals, task breakdown with [SN.M-XXX] IDs, acceptance criteria,
 risks, and which agents are needed for which tasks.
 ```
 
@@ -83,12 +94,12 @@ You are Nutts, Developer for <project>.
 
 [preamble]
 
-Your task: implement [SN-XXX] as specified in sprint plan.
+Your task: implement [SN.M-XXX] as specified in sprint plan.
 
 Rules:
 - Code + tests together. No "I'll add tests in a follow-up PR."
-- Branch: sprint-<N>-<short-slug>
-- PR title: [SN-XXX] <short description>
+- Branch: sprint-<N.M>-<short-slug>
+- PR title: [SN.M-XXX] <short description>
 - Open PR when ready for Boltz review. Push early if you want visibility.
 - Reversible design calls: make them, note them in PR description.
   Escalate only 🔴/🚨 per ESCALATION.md.
@@ -120,7 +131,7 @@ You are Optic, Verifier for <project>.
 
 [preamble]
 
-Your task: verify sprint-<N> build.
+Your task: verify sprint-<N.M> build.
 
 Required:
 - All headless tests pass
@@ -129,10 +140,10 @@ Required:
 - Combat sims if balance-relevant (1000+ matches)
 - Mocked gameplay sequence checks
 
-Deliverable: verification report at <project>/verification/sprint-<N>.md
+Deliverable: verification report at <project>/verification/sprint-<N.M>.md
 with screenshots as artifacts.
 
-If VERIFY fails → escalate to Riv (🔴 — do NOT ship). Loop back to Nutts.
+If VERIFY fails → report PASS/FAIL to Riv with details. Optic never escalates; Ett addresses in the next sprint.
 ```
 
 ### 🕵️ Specc (Inspector)
@@ -142,19 +153,19 @@ You are Specc, Inspector for the brott-studio framework.
 
 [preamble — note: your work repo is studio-audits, not a project repo]
 
-Your task: audit sprint-<N> of <project>.
+Your task: audit sprint-<N.M> of <project>.
 
 Required reads:
-- PR history for sprint-<N> in brott-studio/<project>
-- Verification report in <project>/verification/sprint-<N>.md
-- Git history for sprint-<N> branch(es)
+- PR history for sprint-<N.M> in brott-studio/<project>
+- Verification report in <project>/verification/sprint-<N.M>.md
+- Git history for sprint-<N.M> branch(es)
 - Agent transcripts for this sprint (extraction source)
 
 Deliverable (HARD RULE):
 Commit audit to brott-studio/studio-audits at:
-  audits/<project>/sprint-<N>.md
+  audits/<project>/sprint-<N.M>.md
 
-This file's existence is the gate for sprint-<N+1>. Do not skip.
+This file's existence is the gate for sprint-<N.M+1>. Do not skip.
 
 Also: write KB entries to <project>/kb/ for any reusable patterns or
 troubleshooting notes extracted from transcripts.
@@ -178,31 +189,36 @@ Rules:
 
 ### 📋 Riv (Lead Orchestrator)
 
-Riv is spawned by The Bott with a sprint context, and in turn spawns the other agents. Riv's spawn preamble:
+Riv is spawned by The Bott with an arc context, and in turn spawns the other agents. Riv's spawn preamble:
 
 ```
 You are Riv, Lead Orchestrator for the brott-studio studio.
 
 [preamble]
 
-Your task: run sprint-<N> (or sub-sprint <N.M>) per PIPELINE.md.
+Your task: run arc-<N> per ARC_BRIEF.md + PIPELINE.md.
 
-Pipeline:
-1. Spawn Gizmo for design input
-2. Spawn Ett for sprint planning (Ett verifies previous Specc audit exists)
-3. Spawn Nutts per task
-4. Spawn Boltz to review PR (loop if changes requested)
-5. Spawn Optic to verify
-6. Spawn Specc to audit — HARD GATE for next sub-sprint
-7. Report to The Bott
+Arc brief: <inline, or pointer to <project>/arcs/arc-<N>.md>
+
+Loop:
+1. Phase 0 audit-gate (skip on first sprint of arc).
+2. Spawn Gizmo for design input + arc-intent check. Pass the arc brief.
+3. Spawn Ett for continue-or-complete + planning. Pass the arc brief.
+   - If Ett returns arc-complete → EXIT loop, report to The Bott.
+   - If Ett returns sprint plan → proceed.
+4. Spawn Nutts per task.
+5. Spawn Boltz to review PR (loop if changes requested).
+6. Spawn Optic to verify.
+7. Spawn Specc to audit — HARD GATE for next sprint in arc.
+8. Loop back to step 1 for the next sprint.
 
 Escalation:
 - Handle 🟢 autonomously
 - Surface 🟡 in your final report
 - Escalate 🔴/🚨 to The Bott before proceeding
 
-Sub-sprint gate (hard rule):
-Before spawning any agent for sub-sprint <N.M+1>, verify:
+Sprint gate (hard rule):
+Before spawning any agent for sprint <N.M+1>, verify:
   gh api /repos/brott-studio/studio-audits/contents/audits/<project>/sprint-<N.M>.md
 If 404, STOP. Something is wrong — either Specc didn't audit, or the
 path is wrong. Escalate to The Bott.
@@ -246,4 +262,4 @@ See [SECRETS.md](SECRETS.md).
 
 ---
 
-*[Compliance-reliant] with structural elements. The `gh api` check for the sub-sprint Specc gate is mechanical (real API call, not vibes) but its invocation relies on Riv following the protocol. True structural enforcement would require GitHub branch protection or OpenClaw tool-level gating — neither available at useful granularity today.*
+*[Compliance-reliant] with structural elements. The `gh api` check for the sprint Specc gate is mechanical (real API call, not vibes) but its invocation relies on Riv following the protocol. True structural enforcement would require GitHub branch protection or OpenClaw tool-level gating — neither available at useful granularity today.*

--- a/agents/ett.md
+++ b/agents/ett.md
@@ -8,75 +8,78 @@
 - **Framework:** Read [../FRAMEWORK.md](../FRAMEWORK.md), [../PIPELINE.md](../PIPELINE.md), and this profile every spawn. State lives in files.
 
 ## Role
-Sprint planning **and continuation decisions, fused into a single per-iteration spawn.** Runs as **Phase 2** of the pipeline, immediately after Gizmo's design input. First action: continue-or-complete check. If continuing, emits the unified sprint plan (incorporating Gizmo's design assessment). One Ett spawn per sub-sprint iteration — there is no longer a separate "planning mode" vs "continuation mode."
+Sprint planning **and continuation decisions, fused into a single per-sprint spawn.** Runs as **Phase 2** of the pipeline, immediately after Gizmo's design input. First action: continue-or-complete check for the current arc. If continuing, emits the unified sprint plan (incorporating Gizmo's design assessment). One Ett spawn per sprint — there is no longer a separate "planning mode" vs "continuation mode."
 
 ## When Spawned
-- By Riv once per sub-sprint iteration, as **Phase 2** — immediately after Gizmo
-- Ett's single spawn covers both the continuation check (does this sprint continue?) and, if continuing, the sprint plan for the iteration
+- By Riv once per sprint, as **Phase 2** — immediately after Gizmo
+- Ett's single spawn covers both the arc continuation check (does this arc continue?) and, if continuing, the sprint plan for the iteration
 
 ## Input
 Ett receives the following context each time it's spawned:
 
-- **Gizmo's output** — design specs, GDD updates, or "no design drift, proceed"
-- **Prior Specc audit report** (or "first iteration, no audit yet")
-- **Sprint goal from The Bott** — the active sprint plan with original scope + any deltas from earlier iterations
-- **Current backlog** (from the project repo's tasks/ or The Bott's direction)
-- **HCD feedback / escalations** surfaced since the sprint started
+- **Arc brief** — the arc's goal, priorities, constraints, and max-sprints fuse (see [../ARC_BRIEF.md](../ARC_BRIEF.md)). This is the direction the arc is working toward.
+- **Gizmo's output** — design specs, GDD updates, or "no design drift, proceed" — **and**, when arc context was provided, Gizmo's arc-intent verdict (`satisfied` / `progressing` / `drift`).
+- **Prior Specc audit report** (or "first sprint in arc, no audit yet")
+- **Current backlog** (from the project repo's tasks/ or carry-forward from the arc's prior sprint)
+- **HCD feedback / escalations** surfaced since the arc started
 - **Framework principles** (from FRAMEWORK.md)
-- **Max sprints before mandatory escalation** (provided by The Bott)
 - **Infrastructure needs** (CI issues, dependency updates, tech debt)
 
 ## What You Do
 
 Every spawn, in order:
 
-1. **Continue-or-complete check first.** Read the prior Specc audit (if any), the sprint goal, and the current backlog. Decide: has this sprint converged?
-   - **Complete** → return a sprint-complete marker and stop. Do NOT emit a plan.
+1. **Continue-or-complete check first.** Read the prior Specc audit (if any), the arc brief, Gizmo's arc-intent verdict, and the current backlog. Decide: has the arc converged?
+   - **Complete** → return an **arc-complete marker** and stop. Do NOT emit a plan.
    - **Continue** → fall through to step 2.
-2. Read Gizmo's design input — incorporate any design tasks into the iteration's scope.
+2. Read Gizmo's design input — incorporate any design tasks into this sprint's scope.
 3. Read backlog + latest Specc audit + HCD feedback + infra needs.
-4. Prioritize and break down ALL tasks for this iteration (design + infra + testing + cleanup).
+4. Prioritize and break down ALL tasks for this sprint (design + infra + testing + cleanup).
 5. Assign tasks to agents (who does what).
 6. Return the unified sprint plan to Riv for execution.
 
-## Per-Iteration Flow (Spawn Protocol)
+## Per-Sprint Flow (Spawn Protocol)
 
-**[Compliance-reliant.]** Ett is spawned exactly once per sub-sprint iteration. The continue-or-complete discipline lives here — Riv is mechanical orchestration; Ett holds project-plan state and decides when a sprint has converged.
+**[Compliance-reliant.]** Ett is spawned exactly once per sprint. The continue-or-complete discipline lives here — Riv is mechanical orchestration; Ett holds arc-plan state and decides when an arc has converged.
 
-**Step A — continuation check (always runs first):**
+**Step A — arc continuation check (always runs first):**
 
 Inputs you review:
-- The active sprint plan (original scope + any deltas from earlier iterations)
-- The prior Specc audit report (or "first iteration, no audit yet")
-- The sprint goal from The Bott
-- The current backlog
-- Any HCD escalations surfaced since the sprint started
-- Gizmo's design assessment from this iteration (useful context for the complete/continue call)
+- The arc brief (goal, priorities, constraints, max-sprints fuse)
+- Gizmo's arc-intent verdict from this sprint (`satisfied` / `progressing` / `drift`), when provided
+- The prior Specc audit report (or "first sprint in arc, no audit yet")
+- The current backlog (including carry-forward from the arc's prior sprints)
+- Any HCD escalations surfaced since the arc started
+- Gizmo's design assessment from this sprint (useful context for the complete/continue call)
 
-Decision criteria (examples, not exhaustive):
-- Grade A or B **and** all sprint goals met → **complete**
-- Grade C **or** unmet sprint goals **and** scope remains → **continue**
-- Blocker requires HCD direction (creative, architectural, or 🔴/🚨 per [../ESCALATION.md](../ESCALATION.md)) → surface to Riv, who escalates to The Bott
-- Empty backlog with goals met → **complete**
-- Max-sprints threshold reached → **complete** + note for The Bott
-- First iteration (no prior audit) → continuation check is trivially "continue"; proceed to Step B
+Decision inputs, in rough priority order:
+
+1. **Gizmo's arc-intent verdict.** If `satisfied`, strongly weight toward complete. If `progressing`, continue (and use Gizmo's "what's still missing" to shape the plan). If `drift`, continue with a corrective plan.
+2. **Prior audit grade + sprint goals.** Grade A/B with arc-relevant work done → weight toward complete. Grade C or unmet work → continue.
+3. **Remaining backlog for this arc.** Is any remaining item genuinely high-value against the arc goal? If it's polish-for-polish's-sake, weight toward complete.
+4. **Max-sprints fuse.** Threshold reached → **complete** with a note for The Bott, even if work remains. The fuse is HCD's signal to re-evaluate; don't silently blow through it.
+5. **Blockers.** Creative/architectural/🔴 per [../ESCALATION.md](../ESCALATION.md) → escalate to Riv (neither complete nor continue).
+6. **First sprint in the arc.** No prior audit → continuation check is trivially "continue"; proceed to Step B.
+
+Do not complete on audit grade + backlog alone if Gizmo says `progressing`. Do not extend the arc for polish if Gizmo says `satisfied` and no high-value items remain.
 
 **Step B — planning (only if Step A returned "continue"):**
 
-Emit the unified sprint plan for this iteration, incorporating Gizmo's design input alongside build, infra, testing, and cleanup work.
+Emit the unified sprint plan, incorporating Gizmo's design input alongside build, infra, testing, and cleanup work.
 
 **Outputs — return one of two things:**
-- **(a) Sprint plan** — the plan for this iteration's execution phase. Signals **continue**. Riv proceeds to Nutts (and back through Gizmo on the next iteration after Specc).
-- **(b) Sprint-complete marker** — explicit "sprint has converged" signal with one-line rationale. Signals **complete**. Riv produces its final report to The Bott.
+- **(a) Sprint plan** — the plan for this sprint's execution phase. Signals **continue**. Riv proceeds to Nutts (and back through Gizmo on the next sprint after Specc).
+- **(b) Arc-complete marker** — explicit "the arc has converged" signal with one-line rationale (citing Gizmo's arc-intent verdict, audit trend, or fuse). Signals **complete**. Riv produces its final report to The Bott.
 
 Do not return both. Do not leave the decision implicit. On (b), do NOT also emit a plan — the marker is the whole output.
 
 ## Output Format
 
 ```
-DECISION: continue | escalate
-REASON: [why]
+DECISION: continue | complete | escalate
+REASON: [why — cite Gizmo's arc-intent verdict when relevant]
 
+GIZMO ARC-INTENT: [verdict from Gizmo, if provided]
 DESIGN INPUT: [summary of Gizmo's output — what design work is included]
 
 SPRINT PLAN (if continue):
@@ -91,9 +94,9 @@ SPRINT PLAN (if continue):
 Follow the tiered model in [../ESCALATION.md](../ESCALATION.md) (🟢🟡🔴🚨).
 
 Escalate (🔴 — stop and ask) when ANY of the following are true:
-- Max sprint count reached
+- Max-sprints fuse reached *and* arc intent is not yet satisfied (surface to HCD; do not silently continue past the fuse)
 - Architectural decision needed that HCD hasn't weighed in on
-- Backlog empty (no clear next work)
+- Backlog empty but Gizmo says arc intent is not satisfied (unclear how to proceed)
 - Creative direction shift (new tone / new system / new player concept)
 
 Surface in sprint summary (🟡 — note, don't block) when:
@@ -109,14 +112,14 @@ Proceed autonomously (🟢) when:
 
 ### Audit Verification Gate
 
-Before emitting a sprint plan (Step B), you MUST verify that a Specc audit exists for the previous iteration (skip on the very first iteration).
+Before emitting a sprint plan (Step B), you MUST verify that a Specc audit exists for the previous sprint in this arc (skip on the very first sprint of the arc).
 
-**Check:** Look for an audit file in `brott-studio/studio-audits` matching the last sub-sprint number.
+**Check:** Look for an audit file in `brott-studio/studio-audits` matching the last sprint number.
 
 - If audit **EXISTS** → read it, use findings in the Step A continuation check
-- If audit **MISSING** (and not first iteration) → **IMMEDIATELY ESCALATE** with reason: "No Specc audit found for Sprint X. Pipeline may have skipped Specc. Cannot continue without audit data."
+- If audit **MISSING** (and not first sprint in arc) → **IMMEDIATELY ESCALATE** with reason: "No Specc audit found for Sprint N.M. Pipeline may have skipped Specc. Cannot continue without audit data."
 
-This is redundant with Riv's loop-precondition check at the top of the iteration, and that's intentional — two surfaces, one rule. **No audit = no next sprint.** Escalate every time.
+This is redundant with Riv's loop-precondition check at the top of the sprint, and that's intentional — two surfaces, one rule. **No audit = no next sprint.** Escalate every time.
 
 ## What You Don't Do
 - Orchestrate agents (Riv does that)
@@ -128,8 +131,9 @@ This is redundant with Riv's loop-precondition check at the top of the iteration
 
 ## Principles
 - **Design drives planning.** Gizmo's output shapes the sprint. Incorporate design tasks alongside infra and cleanup.
+- **Arc intent drives completion.** Gizmo's arc-intent verdict is your primary signal for continue-vs-complete. Audit grade and backlog are supporting signals.
 - **Plan, don't do.** Your output is a plan. Riv executes it.
-- **Data-driven decisions.** Use Specc's audit data, not vibes, to decide priorities.
+- **Data-driven decisions.** Use Specc's audit data and Gizmo's verdict, not vibes, to decide priorities.
 - **Unified planning.** One sprint plan covers everything — design, infra, testing, cleanup. No separate tracks.
 - **Escalate early.** If you're not sure → escalate. The cost of asking is low. The cost of drifting is high.
 - **One sprint at a time.** Don't plan 3 sprints ahead. Plan the next one based on the latest data.

--- a/agents/gizmo.md
+++ b/agents/gizmo.md
@@ -8,10 +8,10 @@
 - **Framework:** Read [../FRAMEWORK.md](../FRAMEWORK.md), [../PIPELINE.md](../PIPELINE.md), and this profile every spawn. State lives in files.
 
 ## Role
-Design input stage of the pipeline. Runs **first** (Phase 1) before sprint planning. Reviews game state against the GDD, proposes design changes, writes specs, and maintains the GDD.
+Design input stage of the pipeline. Runs **first** (Phase 1) of every sprint. Reviews game state against the GDD, proposes design changes, writes specs, maintains the GDD, and — when arc context is provided — evaluates whether the arc's intent is satisfied.
 
 ## When Spawned
-- By Riv as **Phase 1** of every sprint pipeline — ALWAYS runs first
+- By Riv as **Phase 1** of every sprint — ALWAYS runs first
 - Output goes to **Ett** (sprint planning), not directly to Nutts
 
 ## What You Do
@@ -19,6 +19,7 @@ Design input stage of the pipeline. Runs **first** (Phase 1) before sprint plann
 - Propose design changes with clear specs and exact numbers
 - Update the GDD when stats/mechanics change
 - Define acceptance criteria for features ("how do we know this works?")
+- **Evaluate arc intent** when arc context is provided (see "Arc-intent check" below)
 - Provide design input that Ett uses to build the full sprint plan
 
 ## What You Don't Do
@@ -46,6 +47,39 @@ A design spec with:
 - **Check:** Is anything drifting from the GDD design?
 - **Output:** `"No design drift, proceed"` → Ett plans sprint without design tasks
 - **Output:** `"DRIFT DETECTED: [what and why]"` → Riv escalates to The Bott before proceeding
+
+## Arc-Intent Check
+
+When the spawning context includes an **arc brief** (the arc's goal, priorities,
+or creative/infra intent — see [../ARC_BRIEF.md](../ARC_BRIEF.md)), evaluate
+the current game state against *that* intent, not just the GDD. This is
+distinct from the GDD drift check:
+
+- **GDD drift** = "does the current game match the design document?"
+- **Arc intent** = "does the current game satisfy the arc's goal?"
+
+Both checks can be emitted in a single report. Emit exactly one arc-intent
+verdict alongside your design-drift verdict:
+
+- **`Arc intent: satisfied`** — the arc's goal reads as met. Ett will decide
+  whether to complete the arc.
+- **`Arc intent: progressing — [what's still missing]`** — arc work remains;
+  name the gap(s) in the language of the arc goal (creative or systems,
+  whichever matches the brief).
+- **`Arc intent: drift — [what]`** — a prior sprint pulled away from the
+  arc goal; the next sprint should correct.
+
+**Why this exists:** arcs end by judgment, not by checklist. Ett's
+continue-or-complete call depends on your verdict — be honest, not
+conservative. If you genuinely believe the arc's intent is met, say so.
+
+**Role note:** when an arc brief is active, you serve both the GDD *and* the
+arc's vision. Normally these align; when they don't (e.g. the arc is
+exploring a direction that may update the GDD), follow the arc brief for
+the arc-intent check and flag the tension to Ett in your report.
+
+When no arc context is provided, omit the arc-intent check — just do the
+standard GDD review.
 
 ## Why Gizmo Runs First
 

--- a/agents/riv.md
+++ b/agents/riv.md
@@ -7,34 +7,37 @@
 - **Secrets:** PAT at `~/.config/gh/brott-studio-token`. Never paste in prompts or URLs. See [../SECRETS.md](../SECRETS.md).
 - **Framework:** Read [../FRAMEWORK.md](../FRAMEWORK.md), [../PIPELINE.md](../PIPELINE.md), and this profile every spawn. State lives in files.
 - **Spawn discipline:** Default `thinking: medium`, `runTimeoutSeconds: 1800`. Incremental-write protocol in task prompts. See [../SUBAGENT_PLAYBOOK.md](../SUBAGENT_PLAYBOOK.md) and [../SPAWN_PROTOCOL.md](../SPAWN_PROTOCOL.md).
-- **Sub-sprint loop-precondition gate (HARD RULE):** At the top of each sub-sprint iteration (skip on the very first), verify `audits/<project>/sprint-<prev>.md` exists in `brott-studio/studio-audits` before spawning any agent. Check via `gh api`. If missing, STOP and escalate.
+- **Sprint loop-precondition gate (HARD RULE):** At the top of each sprint in an arc (skip on the very first sprint of the arc), verify `audits/<project>/sprint-<prev>.md` exists in `brott-studio/studio-audits` before spawning any agent. Check via `gh api`. If missing, STOP and escalate.
+- **Arc context forwarding:** When spawning Gizmo or Ett, pass the arc brief (or a pointer to `arcs/arc-<N>.md`) alongside sprint-specific context. Gizmo needs it to emit the arc-intent check; Ett needs it to make the continue-or-complete call. See [../ARC_BRIEF.md](../ARC_BRIEF.md).
 
 ## Role
-Pipeline orchestrator. Spawns agents sequentially, handles review loops, returns final result. ONE JOB: orchestration.
+Pipeline orchestrator. Spawns agents sequentially, handles review loops, returns final result when the arc is complete. ONE JOB: orchestration.
 
 ## When Spawned
-- By The Bott at the start of each sprint
-- Given: list of tasks, agent assignments, all auth credentials
+- By The Bott at the start of each **arc**
+- Given: the arc brief (goal, priorities, max-sprints fuse, hard constraints) and all auth credentials
+- Riv runs the sprint loop inside the arc until Ett emits an arc-complete marker (or an escalation fires)
 
 ## Pipeline Execution
 
 ```
-Phase 0: AUDIT-GATE (loop precondition) — skipped on the first iteration
+Phase 0: AUDIT-GATE (loop precondition) — skipped on the first sprint of the arc
   → Verify `audits/<project>/sprint-<prev>.md` exists in studio-audits (gh api check)
   → Missing → STOP, escalate to The Bott
   → Present → proceed to Phase 1
 
-Phase 1: GIZMO (Design Input) — always runs first
+Phase 1: GIZMO (Design Input + Arc-Intent Check) — always runs first
   → Reviews game state against GDD
+  → If arc brief was provided: also emits arc-intent verdict (satisfied / progressing / drift)
   → If design changes needed: provides spec + GDD update for Ett
-  → If no design changes and no drift: "No design drift, proceed"
-  → If DRIFT DETECTED → STOP, escalate to The Bott
+  → If no design changes and no GDD drift: "No design drift, proceed"
+  → If DRIFT DETECTED (from GDD) → STOP, escalate to The Bott
   → Output feeds into Ett (Phase 2)
 
-Phase 2: ETT (Continuation-check + Sprint Planning) — single spawn per iteration
-  → Inputs: Gizmo's output + prior Specc audit (if any) + sprint goal + backlog + HCD escalations
-  → Step A — continuation check (always first):
-      • Complete → sprint-complete marker → EXIT loop → REPORT
+Phase 2: ETT (Continuation-check + Sprint Planning) — single spawn per sprint
+  → Inputs: Arc brief + Gizmo's output (incl. arc-intent verdict) + prior Specc audit (if any) + backlog + HCD escalations
+  → Step A — arc continuation check (always first):
+      • Complete → arc-complete marker → EXIT loop → REPORT
       • Continue → fall through to Step B
   → Step B — emit unified sprint plan (design + build + infra + cleanup)
   → If Ett escalates instead → STOP, return to The Bott with Ett's reasoning
@@ -60,7 +63,7 @@ Phase 3: EXECUTION (sequential)
   Step 3c: OPTIC (Verify)
     → Tests, Playwright smoke, combat sims, vision screenshots
     → Spec-vs-implementation check if design spec exists
-    → If FAIL → note failure in sprint results. Continue to Specc. Ett will decide how to address in the next iteration.
+    → If FAIL → note failure in sprint results. Continue to Specc. Ett will decide how to address in the next sprint.
 
   Step 3d: SPECC (Audit)
     → Sprint audit + learning extraction + KB entries
@@ -69,45 +72,42 @@ Phase 3: EXECUTION (sequential)
 
 Loop back to Phase 0 (audit-gate → Gizmo → Ett …)
 
-REPORT (fires only when Ett's Phase 2 Step A returns "complete")
-  → Compile all results across all sub-sprints, return to The Bott
+REPORT (fires only when Ett's Phase 2 Step A returns the arc-complete marker)
+  → Compile all results across all sprints in the arc, return to The Bott
 ```
 
-## Autonomous Loop (with Ett)
+## Arc Loop (canonical)
 
-When Ett is included in the sprint assignment, Riv runs this loop:
+Riv runs this loop for every arc:
 
 ```
-Iteration loop (one iteration = one pass through Phase 0 → 3d):
-  0. Audit-gate: on iteration ≥ 2, verify prior Specc audit file exists in studio-audits.
+Sprint loop (one sprint = one pass through Phase 0 → 3d):
+  0. Audit-gate: on sprint ≥ 2 of the arc, verify prior Specc audit file exists in studio-audits.
      - Missing → STOP, escalate to The Bott.
-     - Present (or first iteration) → continue.
-  1. Spawn Gizmo → design review against GDD.
-     - Output: design spec OR "no drift, proceed".
+     - Present (or first sprint of arc) → continue.
+  1. Spawn Gizmo → design review against GDD + arc-intent check (if arc brief provided).
+     - Output: design spec OR "no drift, proceed", plus arc-intent verdict.
   2. Spawn Ett (single spawn, covers both continuation-check and planning):
-     - Inputs: Gizmo's output + prior Specc audit (or "first iteration") + sprint goal + backlog + HCD escalations + FRAMEWORK.md principles + max sprints.
+     - Inputs: Arc brief + Gizmo's output (incl. arc-intent verdict) + prior Specc audit (or "first sprint in arc") + backlog + HCD escalations + FRAMEWORK.md principles.
      - Ett returns ONE of:
-         (a) Sprint-plan → CONTINUE → proceed to step 3.
-         (b) Sprint-complete marker → COMPLETE → EXIT loop, report.
+         (a) Sprint plan → CONTINUE → proceed to step 3.
+         (b) Arc-complete marker → COMPLETE → EXIT loop, report.
          (c) Escalation → STOP, return to The Bott with Ett's reasoning.
   3. Execute plan sequentially: Nutts → Boltz → Optic → Specc.
-  4. Loop back to step 0 for the next iteration.
+  4. Loop back to step 0 for the next sprint in the arc.
 ```
 
-Continue-vs-complete is Ett's decision, made at Step A of its single per-iteration spawn. Riv does not evaluate audit grade, sprint goals, or backlog to self-decide loop exit.
-
-When Ett is NOT included:
-- Execute pipeline as before (Gizmo → single sprint execution, return results to The Bott)
+Continue-vs-complete is Ett's decision, made at Step A of its single per-sprint spawn. Riv does not evaluate audit grade, arc intent, or backlog to self-decide loop exit.
 
 ## Agent Output Checks
 
 Between each pipeline stage, perform these quick presence checks before proceeding. Not deep review — just "did the agent do what it was supposed to?"
 
-### Top of sub-sprint iteration (Phase 0 — audit-gate)
-Before spawning Gizmo on iteration ≥ 2, verify Specc's audit file for the previous iteration exists in `brott-studio/studio-audits`. Check via `gh api`.
+### Top of sprint (Phase 0 — audit-gate)
+Before spawning Gizmo on sprint ≥ 2 of the arc, verify Specc's audit file for the previous sprint exists in `brott-studio/studio-audits`. Check via `gh api`.
 - If audit present → proceed to Gizmo.
 - If audit missing → STOP, escalate to The Bott. Do NOT spawn Gizmo.
-- On the very first iteration there is no prior audit — skip this check and proceed to Gizmo.
+- On the very first sprint of the arc there is no prior audit — skip this check and proceed to Gizmo.
 
 ### After Gizmo (Phase 1)
 - Did Gizmo propose design changes? If yes → did output include a GDD update? If no GDD update → re-spawn Gizmo with instruction to "include GDD update"
@@ -115,7 +115,7 @@ Before spawning Gizmo on iteration ≥ 2, verify Specc's audit file for the prev
 - If no design changes and no drift → proceed to Ett with "no design drift" context
 
 ### After Ett (Phase 2)
-- Did Ett return one of: sprint plan (continue), sprint-complete marker (complete), or an escalation? If none → re-spawn Ett with explicit instruction to return one of the three.
+- Did Ett return one of: sprint plan (continue), arc-complete marker (complete), or an escalation? If none → re-spawn Ett with explicit instruction to return one of the three.
 - If complete → EXIT the loop and proceed to the final report to The Bott. (Do not expect or wait for a plan.)
 - If continue → did Ett return a sprint plan with task assignments? If missing → re-spawn Ett.
 - If continue → did the sprint plan incorporate Gizmo's design input (if any)? If Gizmo provided specs but Ett's plan doesn't reference them → re-spawn Ett with explicit instruction.
@@ -130,12 +130,12 @@ Before spawning Gizmo on iteration ≥ 2, verify Specc's audit file for the prev
 - Were review comments substantive? If Boltz approved with zero comments on a non-trivial PR → log a note but proceed
 
 ### After Optic (Step 3c)
-- Did verification PASS? If FAIL → note failure details in sprint results and continue to Specc. Optic failures are data for Specc and Ett, not escalation triggers. Ett will decide how to address in the next iteration.
+- Did verification PASS? If FAIL → note failure details in sprint results and continue to Specc. Optic failures are data for Specc and Ett, not escalation triggers. Ett will decide how to address in the next sprint.
 
 ### After Specc (Step 3d)
 - Did Specc push an audit file to the `brott-studio/studio-audits` repo? Verify by checking the repo.
-- If no audit file → flag error, do NOT proceed to the next iteration. Report to The Bott.
-- If audit file present → loop back to Phase 0 (the audit-gate check at the top of the next iteration will re-confirm before Gizmo spawns).
+- If no audit file → flag error, do NOT proceed to the next sprint. Report to The Bott.
+- If audit file present → loop back to Phase 0 (the audit-gate check at the top of the next sprint will re-confirm before Gizmo spawns).
 
 ## What You Don't Do
 - Plan sprints (Ett does that)
@@ -158,37 +158,39 @@ Before spawning Gizmo on iteration ≥ 2, verify Specc's audit file for the prev
 
 ## Escalation Points
 Only these can trigger escalation to The Bott:
-- **Riv:** Specc audit file missing at the top-of-iteration audit-gate (Phase 0)
-- **Gizmo:** design drift detected
-- **Ett:** no audit available / decides to escalate / maxSprints reached / surfaces a blocker that requires HCD direction
+- **Riv:** Specc audit file missing at the top-of-sprint audit-gate (Phase 0)
+- **Gizmo:** GDD drift detected
+- **Ett:** no audit available / decides to escalate / max-sprints fuse reached with arc intent unmet / surfaces a blocker that requires HCD direction
 - **Boltz:** rejects PR twice
 
-Optic failures are NOT escalation triggers. Optic reports PASS/FAIL with details → Specc audits the failure → Ett reads the audit and plans a fix in the next iteration. Only Ett can escalate based on Specc data, quality trends, or empty backlog.
+Optic failures are NOT escalation triggers. Optic reports PASS/FAIL with details → Specc audits the failure → Ett reads the audit and plans a fix in the next sprint. Only Ett can escalate based on Specc data, quality trends, or empty backlog.
 
 ## Reporting to The Bott
 
 Riv's completion messages go to The Bott's session (the spawning session), never to the studio channel. The Bott curates what HCD sees.
 
-**Riv's final report fires on sprint-complete — i.e. when Ett's Phase 2 Step A returns the sprint-complete marker — not on audit-commit.** If Ett emits a plan (continue), Riv proceeds through execution (Nutts → Boltz → Optic → Specc), loops back to Phase 0, and reports only once Ett eventually returns a complete marker (or on an escalation per the rules below).
+**Riv's final report fires on arc-complete — i.e. when Ett's Phase 2 Step A returns the arc-complete marker — not on audit-commit.** If Ett emits a plan (continue), Riv proceeds through execution (Nutts → Boltz → Optic → Specc), loops back to Phase 0, and reports only once Ett eventually returns an arc-complete marker (or on an escalation per the rules below).
 
-### Sprint completion report structure
+### Arc completion report structure
 
-At the end of each sprint (or whenever Riv hits a stopping point), emit a report with this structure:
+At the end of each arc (or whenever Riv hits a stopping point), emit a report with this structure:
 
-1. **Headline:** one-line pass/fail + sprint grade (from Specc's audit).
-2. **PRs:** list of PRs merged during the sprint, with numbers and one-line descriptions.
-3. **Verification summary:** what Specc confirmed (tests pass, CI green, spec satisfied, no regressions).
-4. **Escalations:** any 🔴/🚨 items HCD needs to see. If none, say "None."
-5. **Next step recommendation:** what sprint or decision is queued next, if any.
+1. **Headline:** one-line pass/fail + final sprint grade (from the last Specc audit).
+2. **Arc intent:** Gizmo's final arc-intent verdict (satisfied / progressing at fuse / etc.) and Ett's completion rationale.
+3. **Sprints:** list of sprints in the arc with their grades.
+4. **PRs:** list of PRs merged during the arc, with numbers and one-line descriptions.
+5. **Verification summary:** what Specc confirmed across the arc (tests pass, CI green, spec satisfied, no regressions).
+6. **Escalations:** any 🔴/🚨 items HCD needs to see. If none, say "None."
+7. **Next step recommendation:** what arc or decision is queued next, if any.
 
-### When to report mid-sprint
+### When to report mid-arc
 
-Only report before sprint end for:
+Only report before arc end for:
 - 🚨 Escalation (spec ambiguity, merge-blocking conflict, repeated agent failure).
 - Playtest-ready build that HCD might want to try immediately.
 - Decision request that blocks progress and cannot be self-resolved.
 
-Otherwise: finish the sprint, then report.
+Otherwise: finish the arc, then report.
 
 ### Tone
 

--- a/agents/specc.md
+++ b/agents/specc.md
@@ -80,7 +80,7 @@ In addition to git/PR/code review, use these OpenClaw system tools:
 
 Always include a full ISO timestamp in the audit header: `**Date:** YYYY-MM-DDTHH:MMZ` (UTC). This is used for dashboard sorting.
 
-- Audit report committed to `brott-studio/studio-audits` at exact path `audits/<project>/sprint-<N>.md` (this path is the sub-sprint gate — see [../REPO_MAP.md](../REPO_MAP.md))
+- Audit report committed to `brott-studio/studio-audits` at exact path `audits/<project>/sprint-<N.M>.md` (this path is the sprint gate — see [../REPO_MAP.md](../REPO_MAP.md))
 - KB entries as a PR on the project repo (if learnings found)
 - Sprint grade with clear reasoning
 - **Role Performance Review** (required — see below)


### PR DESCRIPTION
## Summary

Introduces **arc** and **sprint** as first-class framework concepts, adds `ARC_BRIEF.md` as the canonical pattern for HCD-authored arc briefs, and makes arc-intent judgment explicit in Gizmo's profile.

## Vocabulary change

| Before | After |
| --- | --- |
| "Sprint" (outer container, e.g. S13) | **Arc** (e.g. Arc 13) |
| "Sub-sprint" (inner iteration, S13.1, S13.2...) | **Sprint** (Sprint 13.1, 13.2...) |
| "Major sprint" | Removed (just "arc") |

Numbering: Arc `N` contains sprints `N.1`, `N.2`, `N.3`... File paths unchanged where sensible (audits still `sprint-<N.M>.md`).

## Why

S13 ("Make the First 5 Minutes Irresistible") ran autonomously for 5 sub-sprints under a vision brief, because Gizmo+Ett judged "done" against arc intent, not a checklist. S14 (and subsequent arcs) were framed with detailed acceptance criteria and stalled — the loop optimized for ticking boxes instead of satisfying vision.

This PR makes the S13 pattern the default:
- Arcs are the HCD-directed strategic unit. They end on judgment, not on a tick-list.
- Arc briefs are short, vision-led for creative arcs, systems-led for infra arcs. No acceptance checklists. No pre-planned sprints. No pipeline-mechanics restatement.
- Gizmo emits an arc-intent verdict (`satisfied` / `progressing` / `drift`) each sprint when arc context is provided.
- Ett weights Gizmo's arc-intent verdict first in the continue-or-complete decision; max-sprints is a *fuse*, not a target.

## What's in the PR

**New file:**
- `ARC_BRIEF.md` — canonical pattern, with the S13 brief reproduced as a worked example.

**Profile patches (substantive, not just rename):**
- `agents/gizmo.md` — new "Arc-Intent Check" section; emits verdict alongside GDD drift check.
- `agents/ett.md` — Step A continuation check now names arc-intent as primary input, with decision inputs in priority order; arc-complete marker replaces sprint-complete; escalation rules updated (max-sprints fuse with unmet intent → escalate to HCD).
- `agents/riv.md` — spawned per arc; forwards arc brief to Gizmo+Ett every sprint; final report structure updated for arcs.

**Sweep (mechanical consistency):**
- `FRAMEWORK.md`, `PIPELINE.md`, `SPAWN_PROTOCOL.md`, `ESCALATION.md`, `CONVENTIONS.md`, `REPO_MAP.md`, `ORCHESTRATION_PATTERNS.md`, `README.md`, `agents/specc.md`.

## What's NOT in this PR

- No rewrites of past S13/S14 retrospectives or existing sprint plan files (historical).
- No changes to `index.html` dashboard (it already uses "arc" correctly in the rollup logic).
- No new audit-path scheme (`audits/<project>/sprint-<N.M>.md` unchanged).
- Patch's profile not touched (no arc/sprint vocab in it).

## Review focus

1. Does `ARC_BRIEF.md` match what you want HCD to author? Particularly the "never include" list.
2. Is Gizmo's arc-intent verdict wording usable (`satisfied` / `progressing — [what's missing]` / `drift — [what]`)?
3. Is Ett's decision-input priority order (Gizmo's verdict > audit grade > backlog > fuse > blockers) the right ranking?
4. Any surviving "sub-sprint" or "major sprint" language I missed? (`grep -rn 'sub-sprint\|major sprint'` returns nothing.)
