### PR TITLE
feat(agents): use GitHub Issues for cross-sprint backlog carry-forward

### DIFF
--- a/agents/ett.md
+++ b/agents/ett.md
@@ -20,7 +20,7 @@ Ett receives the following context each time it's spawned:
 - **Arc brief** — the arc's goal, priorities, constraints, and max-sprints fuse (see [../ARC_BRIEF.md](../ARC_BRIEF.md)). This is the direction the arc is working toward.
 - **Gizmo's output** — design specs, GDD updates, or "no design drift, proceed" — **and**, when arc context was provided, Gizmo's arc-intent verdict (`satisfied` / `progressing` / `drift`).
 - **Prior Specc audit report** (or "first sprint in arc, no audit yet")
-- **Current backlog** (from the project repo's tasks/ or carry-forward from the arc's prior sprint)
+- **Current backlog** — pulled via GitHub Issues query: `GET /repos/<project>/issues?state=open&labels=backlog` plus any priority filter (e.g. `prio:high`). Cross-reference against the prior audit's carry-forward section to confirm Specc filed issues for everything it flagged. Carry-forward items missing from Issues are a compliance gap — surface in the plan and note for The Bott.
 - **HCD feedback / escalations** surfaced since the arc started
 - **Framework principles** (from FRAMEWORK.md)
 - **Infrastructure needs** (CI issues, dependency updates, tech debt)
@@ -33,8 +33,8 @@ Every spawn, in order:
    - **Complete** → return an **arc-complete marker** and stop. Do NOT emit a plan.
    - **Continue** → fall through to step 2.
 2. Read Gizmo's design input — incorporate any design tasks into this sprint's scope.
-3. Read backlog + latest Specc audit + HCD feedback + infra needs.
-4. Prioritize and break down ALL tasks for this sprint (design + infra + testing + cleanup).
+3. Pull backlog from GitHub Issues (`label:backlog`, open), sorted by priority label. Read the latest Specc audit's carry-forward section. Compare: every carry-forward item should be an open issue. Any gaps are flagged to The Bott in the plan output (under `BACKLOG HYGIENE`).
+4. Prioritize and break down ALL tasks for this sprint (design + infra + testing + cleanup). Every sprint task must reference its source issue (e.g. `[#47] post-movement stuck eval restructure`) or be explicitly marked `new this sprint` if it originated from Gizmo or HCD this cycle.
 5. Assign tasks to agents (who does what).
 6. Return the unified sprint plan to Riv for execution.
 
@@ -82,9 +82,13 @@ REASON: [why — cite Gizmo's arc-intent verdict when relevant]
 GIZMO ARC-INTENT: [verdict from Gizmo, if provided]
 DESIGN INPUT: [summary of Gizmo's output — what design work is included]
 
+BACKLOG HYGIENE (if continue):
+- Carry-forward items from prior audit filed as issues: [✓ all / list gaps by audit section]
+- Backlog query used: [URL to /issues?labels=… query]
+
 SPRINT PLAN (if continue):
-- Task 1: [description] → Agent: [name]
-- Task 2: [description] → Agent: [name]
+- Task 1: [#<issue>] [description] → Agent: [name]
+- Task 2: [#<issue> or `new this sprint`] [description] → Agent: [name]
 - Dependencies: [any]
 - Infra/cleanup: [any maintenance tasks]
 ```

--- a/agents/specc.md
+++ b/agents/specc.md
@@ -25,6 +25,13 @@ Also the studio's institutional memory — extracts learnings from agent transcr
 - Verify process compliance (did the pipeline execute correctly?)
 - Grade the sprint (A/B/C/D/F with clear reasoning)
 
+### 1b. Carry-Forward → GitHub Issues (mandatory)
+- Every technical residual, non-blocking nit, or follow-up you record (sections 4, 7, Appendix B, or wherever they live in the audit) MUST be filed as a GitHub Issue on the **project repo**, not the audits repo.
+- Required labels per issue: `backlog`, one `area:*` label, one `prio:*` label. Use the existing taxonomy — do not invent labels.
+- Link the issue number inline in the audit text (e.g. `Post-movement stuck eval restructure (#123)`). An audit that lists carry-forward items without issue numbers is incomplete.
+- Rationale: the audit is the narrative record; GitHub Issues are the queryable backlog. Ett's next sprint plan pulls from Issues — items that only live in the audit get silently dropped.
+- Do NOT file issues for items already tracked — search open issues with the same label set first and link the existing one if found.
+
 ### 2. Compliance-Reliant Process Detection (Standing Directive)
 - Identify any process that relies on agents choosing to comply
 - For each: describe it, rate risk, recommend structural fix or accept risk


### PR DESCRIPTION
## Why
Carry-forward residuals currently live only in Specc audit prose. Next sprint's planner has to manually read every prior audit, which is unreliable across sprint distance. Narrative loses fidelity over time; queryable state does not.

## Change
Convention-level updates to two agent profiles. No new machinery.

### Specc (`agents/specc.md`)
New section `1b. Carry-Forward → GitHub Issues (mandatory)`:
- Every carry-forward item → GitHub Issue on the project repo (not audits repo)
- Required labels: `backlog` + `area:*` + `prio:*` (existing taxonomy)
- Issue # linked inline in the audit text
- Dedupe by searching open issues with matching labels first

### Ett (`agents/ett.md`)
- `Input` section: `Current backlog` now pulled via `/issues?state=open&labels=backlog` query, cross-referenced against prior audit's carry-forward to catch gaps
- `Per-Sprint Flow` step 3: pull from Issues, compare to prior audit carry-forward, flag gaps
- `Per-Sprint Flow` step 4: every sprint task must reference its source issue or be marked `new this sprint`
- `Output Format`: adds `BACKLOG HYGIENE` section reporting gaps + backlog query URL

## Why convention, not CI-gated
Reliability concern is real (agents must comply). But the feedback loop is short:
- Specc skips filing → Ett's query misses items → next sprint forgets them → next audit surfaces regression

That's a 1–2 sprint visibility window, not months. If we see silent drops 2–3 sprints running, upgrade to a mechanical gate (audit-linter requiring issue links in carry-forward sections). Until then, convention costs nothing.

## HCD sign-off
Discussed with HCD (2026-04-20). Approved going this route first rather than jumping to a CI check.

## Not included
- No changes to other agents (Riv/Gizmo/Nutts/Boltz/Optic)
- No changes to FRAMEWORK.md / PIPELINE.md (convention sits in agent profiles)
- No CI enforcement (see "Why convention" above)
- S14.1 audit grade not retroactively added (HCD called it — leave as `?`)