### PR TITLE
chore(framework): pipeline consistency sweep for Issues-backlog convention

### DIFF
--- a/FRAMEWORK.md
+++ b/FRAMEWORK.md
@@ -72,7 +72,7 @@ Agents are one-shot tools, spawned per pipeline stage by Riv. They don't persist
 | **Review** | 👨‍💻 Boltz | Lead Dev — PR review via GitHub App | Approved + merged, or changes requested |
 | **Verify** | 🎮 Optic | Verifier — headless tests, Playwright smoke tests, visual regression, combat sims, mocked gameplay checks | Verification report + screenshots |
 | **Deploy** | ⚙️ CI/CD | Automated — no agent needed | Live build at URL |
-| **Audit** | 🕵️ Specc | Inspector — audit, learning extraction, KB entries | Audit report (committed to `studio-audits`) + KB updates |
+| **Audit** | 🕵️ Specc | Inspector — audit, learning extraction, KB entries, files backlog issues for carry-forward | Audit report (committed to `studio-audits`) + KB updates + GitHub Issues |
 
 **On-demand:** 🔧 Patch (DevOps) — called only when infrastructure breaks.
 

--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -57,11 +57,11 @@ REPORT → Riv → The Bott (fires only when Ett's Phase 2 Step A returns the ar
 - The arc brief (goal, priorities, max-sprints fuse, hard constraints)
 - Gizmo's design assessment (spec-delta, scope-rethink, or "no drift") **and** arc-intent verdict when arc context is provided
 - The prior Specc audit report (or "first sprint in arc, no audit yet")
-- The current backlog (including carry-forward from the arc's prior sprints)
+- **Current backlog** pulled via GitHub Issues (`GET /repos/<project>/issues?state=open&labels=backlog`, priority-sorted). Cross-referenced against the prior audit's carry-forward section to catch items Specc flagged but didn't file as issues. Gaps reported as `BACKLOG HYGIENE` in the output.
 - Any HCD escalations surfaced since the arc started
 
 **Ett's outputs — one of two things:**
-- **(a) Sprint plan** (continue) — the plan for this sprint's execution phase (design tasks + build + infra + cleanup), incorporating Gizmo's output. Riv proceeds to Nutts.
+- **(a) Sprint plan** (continue) — the plan for this sprint's execution phase (design tasks + build + infra + cleanup), incorporating Gizmo's output. Every task references its source issue (`[#NNN]`) or is marked `new this sprint`. Includes a `BACKLOG HYGIENE` block reporting whether all prior-audit carry-forward items are filed as issues. Riv proceeds to Nutts.
 - **(b) Arc-complete marker** (complete) — explicit "the arc has converged" signal with one-line rationale (citing Gizmo's arc-intent verdict, audit trend, or fuse). Riv exits the loop and produces its final report to The Bott.
 
 Do not return both. Do not leave the decision implicit.

--- a/SPAWN_PROTOCOL.md
+++ b/SPAWN_PROTOCOL.md
@@ -75,7 +75,11 @@ Required reads before deciding:
 - Specc's audit for sprint-<N.M-1> — REQUIRED (unless first sprint in arc).
   Audit lives at: brott-studio/studio-audits → audits/<project>/sprint-<prev>.md
   If missing, FLAG and escalate to Riv before proceeding.
-- Backlog / current issues in <project-repo>
+- Current backlog via GitHub Issues API:
+  `gh api "/repos/brott-studio/<project>/issues?state=open&labels=backlog&per_page=100"`
+  Filter / sort by `prio:*` labels as needed.
+- Cross-reference: every carry-forward item in the prior audit should be an open issue.
+  Gaps go in your output's `BACKLOG HYGIENE` section.
 - Infra needs (ask Patch if uncertain)
 
 Step A — continue-or-complete check first. If complete, emit arc-complete
@@ -83,8 +87,9 @@ marker and stop (no plan).
 
 Step B (if continuing) — deliverable: sprint plan at
 <project>/sprints/sprint-<N.M>.md.
-Include: goals, task breakdown with [SN.M-XXX] IDs, acceptance criteria,
-risks, and which agents are needed for which tasks.
+Include: goals, task breakdown with `[#<issue>]` references (or `new this sprint`),
+[SN.M-XXX] IDs, acceptance criteria, risks, which agents handle which tasks,
+and a `BACKLOG HYGIENE` block.
 ```
 
 ### 💻 Nutts (Developer)
@@ -98,7 +103,7 @@ Your task: implement [SN.M-XXX] as specified in sprint plan.
 
 Rules:
 - Code + tests together. No "I'll add tests in a follow-up PR."
-- Branch: sprint-<N.M>-<short-slug>
+- Branch: sprint-<N.M>-<short-slug> (per CONVENTIONS.md)
 - PR title: [SN.M-XXX] <short description>
 - Open PR when ready for Boltz review. Push early if you want visibility.
 - Reversible design calls: make them, note them in PR description.
@@ -160,15 +165,22 @@ Required reads:
 - Verification report in <project>/verification/sprint-<N.M>.md
 - Git history for sprint-<N.M> branch(es)
 - Agent transcripts for this sprint (extraction source)
+- Open backlog issues on the project repo (to dedupe before filing new ones)
 
-Deliverable (HARD RULE):
-Commit audit to brott-studio/studio-audits at:
-  audits/<project>/sprint-<N.M>.md
+Deliverables (HARD RULES):
 
-This file's existence is the gate for sprint-<N.M+1>. Do not skip.
+1. Commit audit to brott-studio/studio-audits at:
+     audits/<project>/sprint-<N.M>.md
+   This file's existence is the gate for sprint-<N.M+1>. Do not skip.
 
-Also: write KB entries to <project>/kb/ for any reusable patterns or
-troubleshooting notes extracted from transcripts.
+2. File GitHub Issues on brott-studio/<project> for every carry-forward
+   item in the audit (technical residuals, non-blocking nits, follow-ups).
+   Required labels: `backlog` + one `area:*` + one `prio:*`.
+   Link the issue number inline in the audit text (e.g. `(#123)`).
+   Dedupe against open issues before filing.
+
+3. Write KB entries to <project>/kb/ for any reusable patterns or
+   troubleshooting notes extracted from transcripts.
 ```
 
 ### 🔧 Patch (DevOps)

--- a/agents/nutts.md
+++ b/agents/nutts.md
@@ -28,9 +28,9 @@ BUILD stage of the pipeline. Writes game code AND tests together.
 - Make product decisions (that's The Bott)
 
 ## Git Conventions
-- Branch: `nutts/[SN-XXX]-description`
-- PR title: `[SN-XXX] feat/fix/refactor: description`
-- Commits: `[SN-XXX] type: description`
+- Branch: `sprint-<N.M>-<short-slug>` (per [CONVENTIONS.md](../CONVENTIONS.md))
+- PR title: `[SN.M-XXX] <short description>`
+- Commits: `[SN.M-XXX] type: description`
 - Types: `feat`, `fix`, `refactor`, `test`, `docs`
 
 ## Output


### PR DESCRIPTION
## Context

PR #7 landed the Specc → Issues → Ett convention in two agent profiles. This follow-up propagates the same convention across sibling docs so the pipeline reads consistently from any entry point. No behavior change — language/consistency only.

## Changes

### PIPELINE.md
- Ett inputs: references `/issues?labels=backlog` query + cross-reference against prior audit carry-forward
- Ett outputs: notes the `BACKLOG HYGIENE` block + per-task issue reference requirement

### SPAWN_PROTOCOL.md
- Ett template: `gh api` query for backlog + cross-reference step + `BACKLOG HYGIENE` in the deliverable
- Specc template: adds GitHub-Issue-filing requirement with label set + dedupe rule
- Nutts template: branch format aligned with CONVENTIONS.md (`sprint-N.M-slug`), replacing stale `nutts/SN-XXX`

### agents/nutts.md
- Branch + PR-title + commit conventions aligned with CONVENTIONS.md (matches the spawn-template wording)

### FRAMEWORK.md
- Pipeline table Specc row notes audit stage also files backlog issues

## Why now

The pipeline review (today) found:
- Ett's profile said "pull from Issues," PIPELINE.md + SPAWN_PROTOCOL.md still said "backlog / current issues in project-repo" — vague + inconsistent
- Nutts branch format disagreed between profile (`nutts/SN-XXX`) and CONVENTIONS.md (`sprint-N.M-slug`)
- Framework pipeline table didn't hint at Specc's new Issues responsibility

Convention-level sweep. No enforcement yet.