### PR TITLE
fix(readme-status): drop CI-skip marker from auto-update commit

### DIFF
--- a/.github/workflows/readme-status.yml
+++ b/.github/workflows/readme-status.yml
@@ -63,7 +63,11 @@ jobs:
           fi
 
           git add README.md
-          git commit -m "${TITLE} [skip ci]"
+          # Note: no CI-skip marker in the commit message. Loop prevention
+          # is handled structurally by `paths-ignore: [README.md]` on the
+          # push trigger above. A CI-skip marker here would starve any
+          # required status checks on this auto-PR and deadlock auto-merge.
+          git commit -m "${TITLE}"
           git push --force-with-lease origin "$BRANCH"
 
           existing_pr="$(gh pr list --head "$BRANCH" --base "$BASE" --state open --json number --jq '.[0].number' || true)"


### PR DESCRIPTION
## Context

Same bug pattern as battlebrotts-v2 PR #134 (fixed earlier today). The `readme-status.yml` workflow currently commits with a CI-skip marker appended to the title — belt-on-suspenders over the `paths-ignore: [README.md]` rule on the push trigger.

## Why fix now

When bbv2 added required status checks to `verify.yml`, the same CI-skip marker on its auto-PR starved those checks of triggers and deadlocked auto-merge. If studio-framework ever adds required checks to its PR workflow (deploy gating, link-check, etc.), this will re-deadlock exactly the same way.

Loop prevention is already structural via `paths-ignore`. The marker adds nothing and is a future foot-gun.

## Change

One line: remove ` [skip ci]` from the commit message. Adds an inline comment explaining why, so the next person doesn't re-add it.

No behavior change today (no required checks on this repo yet); pre-emptive future-proofing.