### PR TITLE
chore(framework): clarify Rivett→Riv+Ett is role evolution, not retirement

### DIFF
--- a/FRAMEWORK.md
+++ b/FRAMEWORK.md
@@ -79,9 +79,11 @@ Agents are one-shot tools, spawned per pipeline stage by Riv. They don't persist
 ### Retired Roles
 - ~~Glytch (QA)~~ — merged into Optic. One strong Verify stage beats two weak separate stages.
 
-### History: Rivett → Riv + Ett
+### Role Evolution: Rivett → Riv + Ett (both active)
 
-Rivett was the original combined PM + orchestrator role. Initially retired because the orchestration wasn't working — later root-caused to an OpenClaw `maxSpawnDepth` default preventing Rivett from spawning sub-agents effectively (config issue, not a role design flaw). Rivett was brought back and split cleanly into two roles: **Riv** (orchestrator, runs the pipeline) and **Ett** (project manager, plans the sprint). Both are active canon.
+**Status: both Riv and Ett are active canon.** This subsection documents the history for context; it is **not** a "retired" entry.
+
+Rivett was the original combined PM + orchestrator role. It was initially retired because the orchestration wasn't working — later root-caused to an OpenClaw `maxSpawnDepth` default preventing Rivett from spawning sub-agents effectively (config issue, not a role design flaw). Rivett was brought back and split cleanly into two roles: **Riv** (orchestrator, runs the pipeline) and **Ett** (project manager, plans the sprint). See [agents/riv.md](agents/riv.md) and [agents/ett.md](agents/ett.md) for current profiles.
 
 ---
 


### PR DESCRIPTION
## Context

FRAMEWORK.md's Leadership section ends with two adjacent subsections:
1. `### Retired Roles` (one bullet: Glytch)
2. `### History: Rivett → Riv + Ett` (paragraph)

The paragraph's final sentence says "both are active canon," but a reader skimming the heading hierarchy sees "History" next to "Retired" and can conflate them — treating Riv/Ett as retired. This misread showed up in a calibration note today.

## Change

- Rename heading: `History:` → `Role Evolution:` with `(both active)` appended
- Lead the paragraph with an explicit status line: _"Both Riv and Ett are active canon. This subsection documents the history for context; it is not a retired entry."_
- Add profile links to `agents/riv.md` + `agents/ett.md` so a reader can jump to canonical source immediately

No content change to the history narrative. Heading rename + disambiguation lead-in only.