### PR TITLE
[S16.2-002] Specc GitHub App identity wiring

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -12,6 +12,12 @@ How studio agents authenticate to GitHub and handle credentials.
 **Permissions:** `0600` (owner read/write only)
 **Scope:** `brott-studio/*` repos (studio-framework, studio-audits, battlebrotts-v2, etc.)
 
+## 🔐 Specc GitHub App Private Key
+
+**Location on the workspace host:** `~/.config/gh/brott-studio-specc-app.pem`
+**Permissions:** `0600` (owner read/write only)
+**Use:** Read by `~/bin/specc-gh-token` to mint short-lived installation tokens for the `brott-studio-specc` GitHub App. Same "never in prompts/URLs/commits" rule as the PAT above.
+
 ### Why a file, not an env var or inline value
 
 1. **Transcript hygiene.** Every prompt, spawn payload, and announce event is logged. A PAT in a prompt lives in those logs forever. A PAT in a file stays in the file.

--- a/agents/specc.md
+++ b/agents/specc.md
@@ -4,7 +4,7 @@
 
 - **Autonomy default:** Reversible decision? → decide, act, surface in the audit. Escalate only 🔴/🚨 per [../ESCALATION.md](../ESCALATION.md).
 - **Comms:** Report to your spawning session only. Never post to the Discord studio channel. The Bott is the sole channel voice. See [../COMMS.md](../COMMS.md).
-- **Secrets:** PAT at `~/.config/gh/brott-studio-token`. Never paste in prompts, URLs, or commit messages. See [../SECRETS.md](../SECRETS.md).
+- **Identity / auth:** Specc has its own GitHub App identity (`brott-studio-specc[bot]`). For any `gh` or `git` operation requiring write or reviewer identity (PR open, review, merge, issue create/edit), obtain a short-lived installation token by running `~/bin/specc-gh-token` and use that token. The shared PAT at `~/.config/gh/brott-studio-token` is the fallback for read-only metadata queries only (e.g. `gh api /repos/...` reads, search). Never paste either credential in prompts, URLs, or commit messages. See [../SECRETS.md](../SECRETS.md).
 - **Framework:** Read [../FRAMEWORK.md](../FRAMEWORK.md), [../PIPELINE.md](../PIPELINE.md), and this profile every spawn. State lives in files.
 - **Audit repo:** `brott-studio/studio-audits`. Audit path: `audits/<project>/sprint-<N>.md`. See [../REPO_MAP.md](../REPO_MAP.md).
 


### PR DESCRIPTION
## [S16.2-002] Specc GitHub App identity wiring

Wires the production Specc GitHub App (`brott-studio-specc[bot]`) into framework canon.

### Changes (auth/identity only — scope-compliant)

- `agents/specc.md` — Core Rule updated. Specc uses `~/bin/specc-gh-token` to mint short-lived installation tokens for write/reviewer identity operations (PR open, review, merge, issue create/edit). Shared PAT retained as read-only fallback for metadata queries.
- `SECRETS.md` — new entry for the Specc App private key at `~/.config/gh/brott-studio-specc-app.pem` (0600), documenting rotation + usage.

### What is NOT in this PR (per Gizmo invariant)
- No role/authority changes to Specc
- No scope creep into other profiles
- No KB doc (that is S16.2-004 in battlebrotts-v2)
- No env-config (`.env` wiring is workspace-host, not framework-repo)

### Out-of-repo side effects (landed; not captured here)
- `~/.openclaw/.env` updated with `SPECC_APP_ID=3444613` + `SPECC_INSTALLATION_ID=125608421`, mode tightened to 0600. These env vars are the required inputs for `~/bin/specc-gh-token`, so subagent spawns see them automatically.
- Dry-run: `env -i ... source ~/.openclaw/.env; ~/bin/specc-gh-token` mints a real `ghs_...` token. ✓

### Review ask
- **Boltz:** please review in a separate spawn (structural/CI; no game logic affected).
- **Verify:** if CI runs on framework, await green before merge.

Part of S16.2 (per-agent GitHub Apps arc). S16.2-003 (dummy identity-validation PR in battlebrotts-v2) and S16.2-004 (KB doc) follow.