### PR TITLE
PIPELINE: require audit file on studio-audits/main before sub-sprint close

### DIFF
--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -122,6 +122,14 @@ Redundant compliance surfaces:
 
 Specc has been invaluable to pipeline quality. Skipping Specc between sprints has caused real problems — this gate exists because of that history.
 
+### Sub-sprint close-out invariant
+
+The audit-gate is also a **close-out invariant**, not just a loop precondition. A sub-sprint N.M is NOT considered closed until the following has landed:
+
+- [ ] **Audit landed on `studio-audits/main`** at `audits/<project>/v2-sprint-<N.M>.md`. A sub-sprint is NOT considered closed without this file merged. (Earned S16.1→S16.3; see `v2-sprint-16-arc-complete.md`.)
+
+**Why this is mandatory:** three consecutive sub-sprints (S16.1, S16.2, S16.3) closed without their audit file landing on `studio-audits/main`; each was flagged by the next sprint's audit. Treating audit-file-on-main as a hard gate — enforced at close-out, not just at next-sprint-start — prevents the drift.
+
 ## Pipeline Completion Rule
 
 Never notify HCD for playtesting until the FULL pipeline has completed (Design → Plan → Build → Review → Verify → Audit). No shortcuts.


### PR DESCRIPTION
Formalizes the audit-gate as a **close-out invariant** in addition to its existing loop-precondition role.

### What changed

`PIPELINE.md` — 8 new lines under `## Sprint Audit Gate (HARD RULE)`:

- New `### Sub-sprint close-out invariant` sub-section.
- Single mandatory checklist item: audit file must be merged on `studio-audits/main` at `audits/<project>/v2-sprint-<N.M>.md` before a sub-sprint is considered closed.
- 2-sentence rationale citing the S16.1 → S16.3 pattern.

No role definitions, authority boundaries, or sequencing touched.

### Why

From `studio-audits/audits/battlebrotts-v2/v2-sprint-16-arc-complete.md` §5.1 (framework-patch recommendations). Three consecutive sub-sprints (S16.1, S16.2, S16.3) closed without their audit file landing on `studio-audits/main`; each was flagged by the next sprint's audit. Treating audit-file-on-main as a hard gate at close-out (not just at next-sprint-start) prevents the drift.

### Scope

- (1) from §5.1 recommendation: `PIPELINE.md` checklist addition. ✅
- (2) from §5.1 recommendation: optional GitHub Action mechanical enforcement — **not included here** (belt-and-suspenders, can land in a separate PR if HCD wants it).