### PR TITLE
README: point readers to public site at brott-studio.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Pipeline-driven framework for autonomous game development using AI agents.
 
 > **Mission: Quality over speed. Ship it right, not just fast.**
 
+🌐 **Public site:** https://brott-studio.github.io/
+_(This `studio-framework` repo is internal pipeline infrastructure. The old `/studio-framework/` dashboard has been retired.)_
+
 ---
 
 <!-- STATUS:BEGIN -->


### PR DESCRIPTION
Adds a 'Public site' link near the top of the README so anyone landing on the internal framework repo knows there's now a proper public face for the studio at https://brott-studio.github.io/.

Also notes that the old `/studio-framework/` dashboard has been retired.