### PR TITLE
fix(pipeline): enforce sub-sprint audit close-out in Riv and Ett

### DIFF
--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -130,6 +130,11 @@ The audit-gate is also a **close-out invariant**, not just a loop precondition. 
 
 **Why this is mandatory:** three consecutive sub-sprints (S16.1, S16.2, S16.3) closed without their audit file landing on `studio-audits/main`; each was flagged by the next sprint's audit. Treating audit-file-on-main as a hard gate — enforced at close-out, not just at next-sprint-start — prevents the drift.
 
+**Enforcement (three surfaces, one rule):**
+- **Riv** at end of Phase 3 (Step 3e): spawns Specc once for the sub-sprint as a whole, then verifies the audit file is merged on `studio-audits/main` before spawning Ett for the next sub-sprint.
+- **Ett** at **Step 0** (before Step A continuation decision): verifies the prior sub-sprint's audit file exists on `studio-audits/main`; refuses to run the continuation check or emit a plan if missing.
+- **Riv** at Phase 0 (loop precondition at the top of each sub-sprint): re-verifies the prior audit before spawning Gizmo.
+
 ## Pipeline Completion Rule
 
 Never notify HCD for playtesting until the FULL pipeline has completed (Design → Plan → Build → Review → Verify → Audit). No shortcuts.

--- a/agents/ett.md
+++ b/agents/ett.md
@@ -29,7 +29,10 @@ Ett receives the following context each time it's spawned:
 
 Every spawn, in order:
 
-1. **Continue-or-complete check first.** Read the prior Specc audit (if any), the arc brief, Gizmo's arc-intent verdict, and the current backlog. Decide: has the arc converged?
+0. **Audit Verification Gate (run before anything else).** Verify the previous sub-sprint's audit file exists on `studio-audits/main` at `audits/<project>/v2-sprint-<N.M-previous>.md` (skip on the very first sub-sprint of the arc). Check via `gh api repos/brott-studio/studio-audits/contents/audits/<project>/v2-sprint-<N.M-previous>.md?ref=main`.
+   - **Missing** → escalate to The Bott immediately with the missing audit filename. Do NOT run Step A (continuation decision). Do NOT produce a plan.
+   - **Present** (or first sub-sprint in arc) → proceed to step 1.
+1. **Continue-or-complete check.** Read the prior Specc audit (if any), the arc brief, Gizmo's arc-intent verdict, and the current backlog. Decide: has the arc converged?
    - **Complete** → return an **arc-complete marker** and stop. Do NOT emit a plan.
    - **Continue** → fall through to step 2.
 2. Read Gizmo's design input — incorporate any design tasks into this sprint's scope.
@@ -116,14 +119,9 @@ Proceed autonomously (🟢) when:
 
 ### Audit Verification Gate
 
-Before emitting a sprint plan (Step B), you MUST verify that a Specc audit exists for the previous sprint in this arc (skip on the very first sprint of the arc).
+See **Step 0** in "What You Do" above — the gate runs before Step A (continuation decision) and before any plan is produced. The check lives there; this section is retained as a pointer only.
 
-**Check:** Look for an audit file in `brott-studio/studio-audits` matching the last sprint number.
-
-- If audit **EXISTS** → read it, use findings in the Step A continuation check
-- If audit **MISSING** (and not first sprint in arc) → **IMMEDIATELY ESCALATE** with reason: "No Specc audit found for Sprint N.M. Pipeline may have skipped Specc. Cannot continue without audit data."
-
-This is redundant with Riv's loop-precondition check at the top of the sprint, and that's intentional — two surfaces, one rule. **No audit = no next sprint.** Escalate every time.
+**No audit = no next sub-sprint.** Escalate every time. Redundant with Riv's Phase 3e close-out check and Phase 0 loop-precondition, and that's intentional — three surfaces, one rule.
 
 ## What You Don't Do
 - Orchestrate agents (Riv does that)

--- a/agents/riv.md
+++ b/agents/riv.md
@@ -66,9 +66,18 @@ Phase 3: EXECUTION (sequential)
     → If FAIL → note failure in sprint results. Continue to Specc. Ett will decide how to address in the next sprint.
 
   Step 3d: SPECC (Audit)
-    → Sprint audit + learning extraction + KB entries
+    → Sub-sprint audit + learning extraction + KB entries (ONE Specc spawn per sub-sprint, after all tasks in the sub-sprint plan have merged+verified)
+    → Pass: sub-sprint plan file path, list of merged task PR numbers, arc context
     → Uses Inspector GitHub App (APP_ID: 3389931, INSTALLATION_ID: 124234853)
     → Key at /home/openclaw/.config/brott-studio/inspector-app.pem
+
+  Step 3e: SUB-SPRINT CLOSE-OUT (audit-landed gate)
+    → Before re-entering the loop for sub-sprint N.M+1, verify
+      `audits/<project>/v2-sprint-<N.M>.md` is merged on `studio-audits/main`
+      via the GitHub Contents API (`gh api repos/brott-studio/studio-audits/contents/audits/<project>/v2-sprint-<N.M>.md?ref=main`).
+    → Missing → STOP. Escalate to The Bott with the missing audit filename.
+      Do NOT spawn Ett for N.M+1. Do NOT pull tasks from the arc brief unilaterally.
+    → Present → proceed to Loop back.
 
 Loop back to Phase 0 (audit-gate → Gizmo → Ett …)
 


### PR DESCRIPTION
## Problem

S17.1 closed without its Specc audit file landing on `studio-audits/main` — the **4th consecutive sub-sprint** to do so (S16.1, S16.2, S16.3, S17.1). Root-cause investigation this morning traced it to a gap in the pipeline's enforcement model: the audit-gate existed as a **loop precondition** (Riv Phase 0, Ett Step B) but not as a **close-out invariant**. Nothing in the pipeline enforced "audit merged on main before the next sub-sprint plan is produced."

PIPELINE.md already declared the sub-sprint close-out invariant in prose, but no agent profile was wired to enforce it.

## What this PR changes

Wires the invariant into three surfaces, one rule ("Option A" from the audit-miss root-cause report):

- **`agents/riv.md`** — adds **Phase 3e (Sub-sprint close-out)** between Step 3d (Specc) and the loop-back. After Specc runs once for the sub-sprint, Riv verifies `audits/<project>/v2-sprint-<N.M>.md` is merged on `studio-audits/main` via the GitHub Contents API before spawning Ett for N.M+1. Missing → STOP, escalate. Also clarifies Step 3d: Specc spawns **once per sub-sprint** (not per task), passed the sub-sprint plan path + merged task PRs + arc context.
- **`agents/ett.md`** — promotes the Audit Verification Gate from a Step-B prerequisite to **Step 0**, running before Step A (continuation decision) and before any plan is produced. The old subsection is retained as a pointer back to Step 0 so the check lives in exactly one place.
- **`PIPELINE.md`** — the existing `### Sub-sprint close-out invariant` section now attributes enforcement explicitly: Riv Phase 3e + Ett Step 0 + Riv Phase 0 loop precondition.

## Scope

- Only the three files above are touched.
- No changes to FRAMEWORK.md (deferred to the Framework Hardening arc).
- No other agent profiles touched.
- No new config or workflow files.

## Line deltas

- `agents/riv.md`: +9 lines
- `agents/ett.md`: -2 lines (net; Step 0 added, old subsection shortened to a pointer)
- `PIPELINE.md`: +5 lines

## Plan to merge

Squash-merge once CI passes. No Discord post.
