### PR TITLE
[S18.1] Optic+Boltz Apps — SECRETS/SPAWN_PROTOCOL/profile wiring

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -18,6 +18,22 @@ How studio agents authenticate to GitHub and handle credentials.
 **Permissions:** `0600` (owner read/write only)
 **Use:** Read by `~/bin/specc-gh-token` to mint short-lived installation tokens for the `brott-studio-specc` GitHub App. Same "never in prompts/URLs/commits" rule as the PAT above.
 
+## 🔐 Optic GitHub App Private Key
+
+**App ID:** `3459479`
+**Installation ID:** `125974902` (`brott-studio` org)
+**Location on the workspace host:** `~/.config/gh/brott-studio-optic-app.pem`
+**Permissions:** `0600` (owner read/write only)
+**Use:** Read by `~/bin/optic-gh-token` to mint short-lived installation tokens for the `brott-studio-optic` GitHub App. Optic authenticates as this App for check-run posting (`Optic Verified` check on project PRs). Same "never in prompts/URLs/commits" rule as the PAT above.
+
+## 🔐 Boltz GitHub App Private Key
+
+**App ID:** `3459519`
+**Installation ID:** `125975574` (`brott-studio` org)
+**Location on the workspace host:** `~/.config/gh/brott-studio-boltz-app.pem`
+**Permissions:** `0600` (owner read/write only)
+**Use:** Read by `~/bin/boltz-gh-token` to mint short-lived installation tokens for the `brott-studio-boltz` GitHub App. Boltz authenticates as this App for review + merge operations (cross-actor APPROVE on Nutts-authored PRs returns 200 instead of 422 under the shared PAT). Same "never in prompts/URLs/commits" rule as the PAT above.
+
 ### Why a file, not an env var or inline value
 
 1. **Transcript hygiene.** Every prompt, spawn payload, and announce event is logged. A PAT in a prompt lives in those logs forever. A PAT in a file stays in the file.

--- a/SPAWN_PROTOCOL.md
+++ b/SPAWN_PROTOCOL.md
@@ -112,6 +112,20 @@ Rules:
 
 ### 👨‍💻 Boltz (Lead Dev, Reviewer)
 
+**Authentication:** Boltz authenticates as the `brott-studio-boltz` GitHub App for review + merge. The canonical App inventory lives in [SECRETS.md](SECRETS.md).
+
+Preamble auth export block (insert after the standard `[preamble]`, before the task body):
+
+```bash
+# Boltz auth: mint short-lived installation token from the GitHub App.
+# Review + merge run as the App, not as the shared PAT — this is what makes
+# cross-actor APPROVE on Nutts-authored PRs return 200 instead of 422.
+export BOLTZ_APP_ID=3459519
+export BOLTZ_INSTALLATION_ID=125975574
+TOKEN=$(~/bin/boltz-gh-token)
+# Use $TOKEN (not the PAT) for POST /reviews and PUT /merge.
+```
+
 ```
 You are Boltz, Lead Dev and sole merger for <project>.
 
@@ -130,6 +144,20 @@ Rules:
 ```
 
 ### 🎮 Optic (Verifier)
+
+**Authentication:** Optic authenticates as the `brott-studio-optic` GitHub App for check-run posting. The canonical App inventory (App ID, Installation ID, PEM path) lives in [SECRETS.md](SECRETS.md) — refer to it there, not here.
+
+Preamble auth export block (insert after the standard `[preamble]`, before the task body):
+
+```bash
+# Optic auth: mint short-lived installation token from the GitHub App.
+# Never use the shared PAT for operations performed "as Optic" (e.g. check-run POST).
+export OPTIC_APP_ID=3459479
+export OPTIC_INSTALLATION_ID=125974902
+TOKEN=$(~/bin/optic-gh-token)
+# Use $TOKEN (not the PAT) for any git / gh / curl call Optic makes as Optic,
+# including the POST to /repos/{owner}/{repo}/check-runs.
+```
 
 ```
 You are Optic, Verifier for <project>.
@@ -152,6 +180,16 @@ If VERIFY fails → report PASS/FAIL to Riv with details. Optic never escalates;
 ```
 
 ### 🕵️ Specc (Inspector)
+
+**Authentication:** Specc authenticates as the `brott-studio-specc` GitHub App for any write/reviewer-identity operation (audit commits, issue filing, KB PRs). The canonical App inventory lives in [SECRETS.md](SECRETS.md). Preamble auth export pattern (this is the reference template mirrored by Optic and Boltz above):
+
+```bash
+# Specc auth: mint short-lived installation token from the GitHub App.
+TOKEN=$(~/bin/specc-gh-token)
+# Use $TOKEN for write operations. Shared PAT remains the fallback for
+# read-only metadata queries (see specc.md Core Rules).
+```
+
 
 ```
 You are Specc, Inspector for the brott-studio framework.

--- a/agents/boltz.md
+++ b/agents/boltz.md
@@ -27,6 +27,17 @@ REVIEW stage of the pipeline. Reviews all PRs via GitHub App before merge. The q
 - Test the build (that's Optic)
 - Make product decisions (that's The Bott)
 
+## Authentication (GitHub App token)
+
+Boltz authenticates as the `brott-studio-boltz` GitHub App for review + merge operations. The shared PAT at `~/.config/gh/brott-studio-token` is no longer used for "as Boltz" actions.
+
+- **Token mint:** `TOKEN=$(~/bin/boltz-gh-token)`. App inventory (App ID, Installation ID, PEM path): [../SECRETS.md](../SECRETS.md).
+- **Review-then-merge flow:** use `$TOKEN` as the bearer for `POST /repos/{owner}/{repo}/pulls/<PR>/reviews` (APPROVE) and `PUT /repos/{owner}/{repo}/pulls/<PR>/merge`.
+- **Cross-actor APPROVE:** Nutts-authored PRs reviewed by Boltz-as-App now return HTTP 200 on the APPROVE call instead of the 422 seen under the shared PAT (where both identities collapsed onto the same token).
+- **Same-actor 422 edge:** a platform-level 422 still exists when the approving identity equals the PR author identity (e.g. Boltz approving its own PR). Documented in `docs/kb/shared-token-self-review-422.md` (in `brott-studio/battlebrotts-v2`, link textually — do not clone that repo just to read it). Mitigation: don't author + approve as the same App.
+- **Auto-merge shadow:** on PRs with auto-merge enabled, once required checks go green the merge commit may be executed by `github-actions[bot]` rather than Boltz itself. This is benign for audit — Boltz's APPROVE remains the gating reviewer event; `github-actions[bot]` is just the mechanical merger. Specc's audit should treat Boltz's APPROVE timestamp as the review event, not the merge commit author.
+- **Cross-references:** [../SECRETS.md](../SECRETS.md) (Boltz App inventory) and `docs/kb/per-agent-github-apps.md` (in `brott-studio/battlebrotts-v2`, link textually).
+
 ## Review Checklist
 For every PR, verify:
 - [ ] Implements what the task spec says (not more, not less)
@@ -38,7 +49,7 @@ For every PR, verify:
 - [ ] No unrelated changes bundled in
 
 ## GitHub App Auth
-Boltz merges via the Studio Lead Dev GitHub App (APP_ID and key provided in spawn prompt). This is the sole merge mechanism — no one else merges to main.
+Boltz merges via the `brott-studio-boltz` GitHub App (see the Authentication section above for token-mint command and edge cases; App inventory in [../SECRETS.md](../SECRETS.md)). This is the sole merge mechanism — no one else merges to main.
 
 ## Output
 - Approved + squash merged PR, OR

--- a/agents/optic.md
+++ b/agents/optic.md
@@ -49,6 +49,31 @@ Combines what was previously two roles (QA + Playtest Lead) into one comprehensi
 - These serve as visual evidence for The Bott and Human
 - Store as PR artifacts or in docs/verification/
 
+## Check-run posting
+
+After local verify completes (PASS or FAIL), Optic posts a GitHub check-run to the project repo so branch protection on `main` can gate merges on `Optic Verified`.
+
+- **Auth:** `TOKEN=$(~/bin/optic-gh-token)`. Use `$TOKEN` (not the shared PAT) for the POST. Optic App inventory: [../SECRETS.md](../SECRETS.md).
+- **Endpoint:** `POST https://api.github.com/repos/{owner}/{repo}/check-runs`
+- **Header:** `Authorization: Bearer $TOKEN`
+- **Head SHA:** fetch from the PR, e.g. `gh api /repos/{owner}/{repo}/pulls/<PR> | jq -r .head.sha` (or equivalent `curl`).
+- **Body shape:**
+  ```json
+  {
+    "name": "Optic Verified",
+    "head_sha": "<PR head SHA>",
+    "status": "completed",
+    "conclusion": "success" | "failure",
+    "output": {
+      "title": "Optic verification",
+      "summary": "<one-line PASS/FAIL summary>"
+    }
+  }
+  ```
+- **Conclusion map:** `success` on PASS, `failure` on FAIL. No `skipped` / `cancelled` / `neutral` states — Optic always produces a binary verdict.
+- **Timing:** fires AFTER local verify produces its verdict, BEFORE Optic returns to Riv. The check-run is part of the verify stage, not an afterthought.
+- **Error handling:** on HTTP non-2xx from the check-run POST, Optic reports the failure to Riv (include status code + response body in the return). Never silently drop — a missing check-run blocks merge forever because branch protection requires it.
+
 ## What You Don't Do
 - Write game code (that's Nutts)
 - Design balance changes (that's Gizmo — you provide data, Gizmo decides)

--- a/agents/specc.md
+++ b/agents/specc.md
@@ -17,6 +17,8 @@ Also the studio's institutional memory — extracts learnings from agent transcr
 - After every sprint completes (mandatory)
 - By The Bott directly (never by other agents — independence)
 
+Note: merging `battlebrotts-v2:main` requires `Optic Verified` as a branch-protection-required check; structural gate, see S18.1.
+
 ## What You Do
 
 ### 1. Sprint Audit


### PR DESCRIPTION
Closes the doc/profile-wiring portion of Sprint 18.1:

- [S18.1-005] `SECRETS.md`: Optic App + Boltz App inventory entries (App ID, Installation ID, PEM path, 0600 note, token-helper path), shape matched to the existing Specc entry.
- [S18.1-006] `SPAWN_PROTOCOL.md`: per-agent preamble export blocks for Optic and Boltz (`OPTIC_APP_ID`/`OPTIC_INSTALLATION_ID` + `~/bin/optic-gh-token`; `BOLTZ_*` mirror). `$TOKEN` is used for as-App operations, never the PAT. Authentication sub-header callouts point at `SECRETS.md` as the canonical App inventory. Specc preamble preserved as the reference template.
- [S18.1-007 / S18.1-009] `agents/optic.md`: new "Check-run posting" operational section — endpoint, auth (`$TOKEN` from `~/bin/optic-gh-token`), body shape, `success`/`failure` conclusion map, head-SHA fetch, timing (after verdict, before return to Riv), HTTP non-2xx error handling.
- [S18.1-010] `agents/boltz.md`: new "Authentication (GitHub App token)" operational section — token mint, review-then-merge flow, cross-actor APPROVE 200 vs. same-actor 422 edge, `github-actions[bot]` auto-merge shadow, cross-refs to `SECRETS.md` and `docs/kb/per-agent-github-apps.md` (textual link, KB lives in `battlebrotts-v2`). Existing "GitHub App Auth" line updated to point at the new section.
- [S18.1-011] `agents/specc.md`: single-line cross-reference — `Note: merging battlebrotts-v2:main requires Optic Verified as a branch-protection-required check; structural gate, see S18.1.`

**Evidence pointer:** Token helpers deployed and verified in S18.1-003 / S18.1-004 (host-local on the workspace VM, not committed to repo).

**Scope note:** AC-1 / AC-2 end-to-end validation tests run in subsequent tasks (S18.1-012, S18.1-013). This PR is framework-doc wiring only.

**Sprint plan:** [brott-studio/battlebrotts-v2 → sprints/sprint-18.1.md](https://github.com/brott-studio/battlebrotts-v2/blob/main/sprints/sprint-18.1.md)

**Pre-commit secret sweep:** clean — only pre-existing doc template strings match (`grep -rE '(ghp_|github_pat_|ghs_|x-access-token:)'` in `SECRETS.md` / `SPAWN_PROTOCOL.md` are documentation examples, no credentials introduced).
