### PR TITLE
[S18.2-009] docs: dedupe ESCALATION.md references across agent profiles

### DIFF
--- a/agents/boltz.md
+++ b/agents/boltz.md
@@ -58,6 +58,6 @@ Boltz merges via the `brott-studio-boltz` GitHub App (see the Authentication sec
 ## Principles
 - **You have merge authority.** Two-approvals-unlock: your approval + author's self-review of tests passing is enough for reversible work. Don't block waiting for permission.
 - **Substantive reviews.** "LGTM" is not a review. Explain what you checked and why it's good.
-- **Reversibility trumps caution.** A reversible merge can be fixed next sprint. A held PR blocks everyone. Hold only for genuine risk (🔴 per [../ESCALATION.md](../ESCALATION.md)) — nits go in the next sprint, not as blockers.
+- **Reversibility trumps caution.** A reversible merge can be fixed next sprint. A held PR blocks everyone. Hold only for genuine risk — nits go in the next sprint, not as blockers.
 - **Be specific when requesting changes.** "This is wrong" helps no one. "Line 42: this should use `load()` instead of `preload()` because X" helps everyone.
 - **Nits go forward, not sideways.** If it's not worth blocking, it's not worth a review round-trip. Surface it in the PR merge comment for the next sprint to pick up.

--- a/agents/ett.md
+++ b/agents/ett.md
@@ -61,7 +61,7 @@ Decision inputs, in rough priority order:
 2. **Prior audit grade + sprint goals.** Grade A/B with arc-relevant work done → weight toward complete. Grade C or unmet work → continue.
 3. **Remaining backlog for this arc.** Is any remaining item genuinely high-value against the arc goal? If it's polish-for-polish's-sake, weight toward complete.
 4. **Max-sprints fuse.** Threshold reached → **complete** with a note for The Bott, even if work remains. The fuse is HCD's signal to re-evaluate; don't silently blow through it.
-5. **Blockers.** Creative/architectural/🔴 per [../ESCALATION.md](../ESCALATION.md) → escalate to Riv (neither complete nor continue).
+5. **Blockers.** Creative/architectural/🔴 items → escalate to Riv (neither complete nor continue).
 6. **First sprint in the arc.** No prior audit → continuation check is trivially "continue"; proceed to Step B.
 
 Do not complete on audit grade + backlog alone if Gizmo says `progressing`. Do not extend the arc for polish if Gizmo says `satisfied` and no high-value items remain.
@@ -98,9 +98,9 @@ SPRINT PLAN (if continue):
 
 ## Escalation Criteria
 
-Follow the tiered model in [../ESCALATION.md](../ESCALATION.md) (🟢🟡🔴🚨).
+Tier model (🟢🟡🔴🚨) is canonical — see the link in Core Rules above. Ett-specific 🔴 triggers:
 
-Escalate (🔴 — stop and ask) when ANY of the following are true:
+Escalate (🔴 — stop and ask) to Riv when ANY of the following are true:
 - Max-sprints fuse reached *and* arc intent is not yet satisfied (surface to HCD; do not silently continue past the fuse)
 - Architectural decision needed that HCD hasn't weighed in on
 - Backlog empty but Gizmo says arc intent is not satisfied (unclear how to proceed)

--- a/agents/nutts.md
+++ b/agents/nutts.md
@@ -41,4 +41,4 @@ BUILD stage of the pipeline. Writes game code AND tests together.
 - **Code + tests ship together.** No code without tests. No tests without code.
 - **Implement the spec, not your interpretation.** If the spec says X, build X. If you think Y is better, note it in the PR but build X.
 - **Small commits, clear messages.** Each commit is a logical unit.
-- **Reversible? Decide.** Make the call, note the tradeoff in the PR description. Escalate only 🔴/🚨 items (see [../ESCALATION.md](../ESCALATION.md)). A question in the PR description beats building the wrong thing — but only when the decision is actually ambiguous. Most calls are reversible.
+- **Reversible? Decide.** Make the call, note the tradeoff in the PR description. Escalate only 🔴/🚨 items to Ett/Riv. A question in the PR description beats building the wrong thing — but only when the decision is actually ambiguous. Most calls are reversible.

--- a/agents/the-bott.md
+++ b/agents/the-bott.md
@@ -33,7 +33,7 @@
 - **Creative-vision asks:** tone, direction, feel invariants, playtest interpretation.
 - **Playtest-ready builds:** HCD plays, decides what ships.
 - **HCD time asks:** "play for 5 min" / "review this draft" / scheduling anything on HCD's calendar. Surface at **trigger-time** (build/draft ready), not at plan-time.
-- **Genuine 🔴/🚨 escalations** per `ESCALATION.md`.
+- **Genuine 🔴/🚨 escalations** per [../ESCALATION.md](../ESCALATION.md).
 - **Ambiguous direction:** when the arc brief itself no longer points clearly and a creative call is needed to continue.
 
 ### Bounce to Riv (not HCD, not me)
@@ -150,7 +150,7 @@ Same as above — spawn canonical Riv. If it escalates overnight, the completion
 - **Buffer, not router.** My job is to absorb decisions the pipeline is supposed to absorb. Passing them through is a failure mode, even when the pipeline asks.
 - **Quality over speed.** HCD's stated preference. If a spec, plan, or audit needs extra time, it gets it — don't rush for a fast turnaround.
 - **Investigate, then fix.** When something goes wrong (bad escalation, process breach, skipped gate), trace the root cause and patch it. Receipts to the docket.
-- **Persistent fixes over in-session fixes.** Rules that matter across sessions go into files (SOUL.md, USER.md, this profile, ESCALATION.md, agent profiles) — not "mental notes."
+- **Persistent fixes over in-session fixes.** Rules that matter across sessions go into files (SOUL.md, USER.md, this profile, the escalation policy, agent profiles) — not "mental notes."
 - **Don't revive retired things.** Closed ≠ reopen. Deleted ≠ restore. Retired ≠ revive. Check prior decisions before resurrecting.
 - **Trust agent recommendations when they've done the work.** If Gizmo or Ett has analyzed a decision and produced a recommendation with reasoning, default to their rec unless I have a real concern.
 


### PR DESCRIPTION
## [S18.2-009] Dedupe `ESCALATION.md` references across agent profiles

**Principle:** *Link, not mirror.* Each agent profile gets **exactly one** canonical link to `../ESCALATION.md` (in Core Rules, near top). Agent-specific nuance lives below without re-linking or re-stating the tier bullets (🟢🟡🔴🚨). The canonical tier table lives in `ESCALATION.md` — profiles should not mirror it.

### What changed

- **`boltz.md`** (2 → 1): Removed redundant `[../ESCALATION.md]` link from the "Reversibility trumps caution" nuance line. Kept the rule-of-thumb; dropped the re-link.
- **`ett.md`** (3 → 1): Removed re-link from the numbered "Blockers" item; removed re-link + tier-mirror sentence ("Follow the tiered model in [../ESCALATION.md] (🟢🟡🔴🚨)") that opened the Escalation Criteria section, replacing it with a brief pointer back to Core Rules so the ett-specific 🔴 triggers stand alone.
- **`nutts.md`** (2 → 1): Removed parenthetical `(see [../ESCALATION.md])` from the "Reversible? Decide." nuance line; rewrote to escalate to Ett/Riv directly.
- **`the-bott.md`** (2 → 1): Upgraded the Core Rules mention from inline-code `` `ESCALATION.md` `` to the canonical link `[../ESCALATION.md](../ESCALATION.md)`; neutralized the second occurrence (which was in a file list about persistence targets, not a tier reference) to "the escalation policy" so the file mention doesn't double-count against the link-budget.

### Before / After grep counts

```
                     BEFORE  AFTER
agents/boltz.md        2       1
agents/ett.md          3       1
agents/gizmo.md        1       1
agents/nutts.md        2       1
agents/optic.md        1       1
agents/patch.md        1       1
agents/riv.md          1       1
agents/specc.md        1       1
agents/the-bott.md     2       1
```

All 9 profiles now at exactly 1 `ESCALATION.md` reference.

### Audit notes

- **Patch audited per S18.2; will be folded into Nutts in S18.5.**
- Compliant profiles (`gizmo`, `optic`, `patch`, `riv`, `specc`) were checked for inline tier-bullet duplication (`🟢🟡🔴🚨`); none found. Not touched.
- Meaning preserved throughout: lines that used to say "escalate X per ESCALATION.md" now say "escalate X to [target]" and rely on the single top-level link in Core Rules to carry the reader to the tier table.
- Secret sweep (`grep -rE '(ghp_|github_pat_|x-access-token:)' . --exclude-dir=.git`) over `agents/` returned clean. Hits elsewhere in the repo are doc-pattern examples in `SECRETS.md` / `SPAWN_PROTOCOL.md` — not real secrets.

### Exceptions

None.
