### PR TITLE
[S18.2-007,-008] docs: BOOTSTRAP_NEW_PROJECT + per-agent GitHub App bootstrap recipe

### DIFF
--- a/BOOTSTRAP_NEW_PROJECT.md
+++ b/BOOTSTRAP_NEW_PROJECT.md
@@ -1,0 +1,130 @@
+# BOOTSTRAP_NEW_PROJECT.md — Cold-start a new project under the studio framework
+
+**Audience:** a studio agent (or HCD) bringing a fresh project repo under the
+studio pipeline for the first time.
+**Goal:** a cold-start agent can run these 5 steps end-to-end without
+blocking questions.
+**Scope:** one project repo (e.g. `brott-studio/<new-project>`), not the
+framework itself. The framework and the audits repo already exist.
+**Status this sprint (S18.2):** docs only — no validation pass this sprint
+(cold-start validation runs in S18.3).
+
+Throughout, `<project>` is the new project's repo name (e.g. `battlebrotts-v2`
+for the canonical precedent). Nothing in the pipeline hardcodes a specific
+project name except where documented in `REPO_MAP.md`.
+
+---
+
+## 1. Create the project repo
+
+Create `brott-studio/<project>` with the minimum skeleton:
+
+```
+<project>/
+  sprints/                       # sprint plans land here (sprint-<N>.<M>.md)
+  arcs/                          # arc briefs (arc-<N>.md)
+  docs/gdd.md                    # game design doc (or project charter)
+  .github/workflows/             # CI workflows
+```
+
+Commit a stub `README.md`, a `.gitignore`, and an empty `docs/gdd.md` (HCD
+fills in the GDD after [arcs/arc-1.md](#5-first-arc-kickoff) is written).
+Set `main` as the default branch.
+
+No other boilerplate this early — the pipeline docs live in
+[studio-framework](.) and are referenced by link, not copied.
+
+## 2. Provision per-agent GitHub Apps
+
+Studio pipeline uses three GitHub Apps as per-agent identities:
+
+| App | Role | Install permissions (min) |
+|---|---|---|
+| `brott-studio-specc` | Audits — writes to `studio-audits` | Contents: write on `studio-audits`; Metadata: read on `<project>` |
+| `brott-studio-boltz` | Reviewer/merger — operates on project repos; also reads `studio-audits` for the `Audit Gate` check | Contents: write, Pull-requests: write on `<project>`; Contents: read on `studio-audits` |
+| `brott-studio-optic` | Check-run reporter — reports build/verify status | Checks: write, Metadata: read on `<project>` |
+
+For each App, install it on the new `<project>` repo and write the private
+key to `~/.config/gh/brott-studio-<agent>-app.pem` on the workspace host
+(`0600`). Confirm with `GET /repos/brott-studio/<project>/installation`
+authenticated as the App (returns `app_id: <App ID>`). Also confirm Specc's
+install on `studio-audits` still has Contents: write, and Boltz's install on
+`studio-audits` still has Contents (read is sufficient for the `Audit Gate`
+check).
+
+**See [`SECRETS.md` §Per-Agent GitHub App Bootstrap](SECRETS.md#per-agent-github-app-bootstrap)**
+for the full create → install → write-key → mint-token → verify recipe, plus
+worked examples using Optic (App ID 3459479) and Boltz (App ID 3459519).
+
+## 3. Wire secrets + CI gates
+
+On `<project>`:
+
+1. Copy the three required workflows from `battlebrotts-v2/.github/workflows/`:
+   - `audit-gate.yml` + `scripts/audit_gate.py` (+ tests) — **parameterise**:
+     replace `battlebrotts-v2` with `<project>` in `audit_gate.py` constants
+     (`PROJECT`, `AUDIT_PATH_TEMPLATE` is derived from `PROJECT`). Do NOT
+     hardcode `battlebrotts-v2` anywhere in the new project.
+   - Whatever build/verify workflows the project needs (for Godot projects:
+     `verify.yml` + `build-and-deploy.yml`; for other projects: the analog).
+2. Add repo-level Actions secrets:
+   - `BOLTZ_APP_ID` — Boltz App's numeric ID (3459519).
+   - `BOLTZ_APP_PRIVATE_KEY` — PEM contents from
+     `~/.config/gh/brott-studio-boltz-app.pem`.
+3. Branch protection on `main` (skeleton matching `battlebrotts-v2`):
+   - Required status checks: start with `Audit Gate`; add project-specific
+     verify checks (e.g. `Godot Unit Tests`, `Optic Verified`) as the
+     project's verify workflow lands.
+   - Require a PR for all changes.
+   - (Scope-gated for S18.4: `enforce_admins`, `restrictions`, bypass lists.
+     Do **not** set these during bootstrap — they're wired project-by-project
+     after the audit-gate is proven live.)
+4. Point `Audit Gate` at `studio-audits:audits/<project>/` by verifying
+   `PROJECT` in `audit_gate.py` matches `<project>` exactly.
+
+## 4. Point the framework at the new project
+
+On `studio-framework`:
+
+1. Update [`REPO_MAP.md`](REPO_MAP.md) to list `<project>`: its role, the
+   agents that write to it, and the cross-links to arcs/sprints/audits
+   locations.
+
+On `studio-audits`:
+
+2. Create `audits/<project>/` with a short `README.md` that names the
+   project, links back to the project repo, and notes that files land as
+   `v2-sprint-<N>.<M>.md` (or the project-specific naming convention).
+
+No hardcoded `battlebrotts-v2` should remain in any file pointing at the new
+project. Search the new project's workflows for the string
+`battlebrotts-v2` — if anything matches outside comments explaining the
+canonical precedent, parameterise it.
+
+## 5. First-arc kickoff
+
+1. **HCD** writes `arcs/arc-1.md` — the arc brief for the project's first
+   arc. See [`ARC_BRIEF.md`](ARC_BRIEF.md) for the shape.
+2. **The Bott** spawns Riv with the arc brief.
+3. Riv spawns Gizmo → Ett → Nutts → Boltz → Optic → Specc as usual.
+4. The first sprint's planning PR (`sprints/sprint-1.1.md`) triggers the
+   `Audit Gate` workflow, which hits the **first-sprint-of-arc rule**:
+   `M == 1` → `Audit Gate` **requires `arcs/arc-1.md` in the PR tree** and
+   **skips the prior-audit lookup**. Present → PASS. Missing → FAIL with
+   summary `"first sprint of an arc must introduce arcs/arc-<N>.md"`.
+5. From `sprint-1.2.md` onward, `Audit Gate` enforces the
+   immediately-preceding audit: `audits/<project>/v2-sprint-1.1.md` on
+   `studio-audits/main`.
+
+That's it. The project is live in the pipeline.
+
+---
+
+## Cross-references
+
+- Secrets + per-agent App bootstrap recipe: [SECRETS.md](SECRETS.md)
+- Pipeline stages and close-out invariant: [PIPELINE.md](PIPELINE.md)
+- Repo map / who writes where: [REPO_MAP.md](REPO_MAP.md)
+- Arc brief shape: [ARC_BRIEF.md](ARC_BRIEF.md)
+- Canonical precedent: `battlebrotts-v2` (study its `.github/workflows/` for
+  the current audit-gate implementation).

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -33,6 +33,7 @@ How studio agents authenticate to GitHub and handle credentials.
 **Location on the workspace host:** `~/.config/gh/brott-studio-boltz-app.pem`
 **Permissions:** `0600` (owner read/write only)
 **Use:** Read by `~/bin/boltz-gh-token` to mint short-lived installation tokens for the `brott-studio-boltz` GitHub App. Boltz authenticates as this App for review + merge operations (cross-actor APPROVE on Nutts-authored PRs returns 200 instead of 422 under the shared PAT). Same "never in prompts/URLs/commits" rule as the PAT above.
+**Scope note (S18.2-001):** The Boltz App installation is **org-level** (`brott-studio`) with `repository_selection: selected`. The same installation ID (`125975574`) covers `studio-framework`, `battlebrotts-v2`, AND `studio-audits`. `GET /repos/brott-studio/studio-audits/installation` returns this ID — no separate studio-audits-scoped installation exists or is needed. The App's Contents permission is `write` at the App level; effective usage against `studio-audits` is read-only (enforced by the `Audit Gate` workflow logic, which only issues GETs).
 
 ### Why a file, not an env var or inline value
 
@@ -93,6 +94,116 @@ grep -rE '(ghp_|github_pat_)' /path/to/repos --exclude-dir=.git
 ```
 
 If a token is exposed: **rotate immediately** (overwrite `~/.config/gh/brott-studio-token`, revoke the old one on GitHub), then do a git history rewrite only if the leak is in public history.
+
+---
+
+## Per-Agent GitHub App Bootstrap
+
+How to stand up a new per-agent GitHub App for a studio role, or install an
+existing one on a new project repo. Canonical worked examples: Optic (App ID
+`3459479`, org installation `125974902`) and Boltz (App ID `3459519`, org
+installation `125975574`). See also
+[BOOTSTRAP_NEW_PROJECT.md](BOOTSTRAP_NEW_PROJECT.md) §2 for the
+new-project-bringup context.
+
+### 1. Create the App (org-level)
+
+Create the App under the `brott-studio` organisation (org-owned, not
+personal). Settings:
+
+- **Homepage URL:** `https://github.com/brott-studio`
+- **Webhook:** disabled (uncheck "Active"; agents poll the API, no webhook
+  consumer exists).
+- **Install on:** "Only on this account" (org-scoped; do not allow
+  installations on arbitrary accounts).
+- **Request user authorization:** off.
+
+**Permissions (minimum per role):**
+
+| Role | Contents | Pull-requests | Checks | Metadata | Notes |
+|---|---|---|---|---|---|
+| Specc (audits) | Write on `studio-audits`; Read on project repos | — | — | Read | Writes audit files; reads project state. |
+| Boltz (reviewer/merger) | Write on project repos; Read on `studio-audits` | Write | — | Read | Reviews + merges PRs; reads audits for `Audit Gate`. |
+| Optic (check-run reporter) | Read on project repos | — | Write | Read | Posts `Optic Verified` + `Audit Gate`-adjacent check-runs. |
+
+Record the App ID (6-7 digit number) shown after creation — you'll need it
+for the token-mint helper and for Actions secrets.
+
+### 2. Install on the target repo
+
+Either path is fine; the web UI is the common case for first-time install.
+
+**Web-UI path (first-time install on a new repo):**
+
+1. Go to `https://github.com/organizations/brott-studio/settings/apps/brott-studio-<agent>/installations`.
+2. On the `brott-studio` installation row, click **Configure**.
+3. Under "Repository access," select "Only select repositories" and add the
+   new repo. Save.
+4. Record the **installation ID** from the URL
+   (`.../installations/<INSTALLATION_ID>`). For org-scoped installs this ID
+   is stable across repo-set changes.
+
+**API path (confirming install or scripting adds to existing installations):**
+
+```bash
+# Confirm the App is installed on a given repo (auth as the App JWT):
+curl -sS -H "Authorization: Bearer $JWT" \
+     -H "Accept: application/vnd.github+json" \
+     https://api.github.com/repos/brott-studio/<repo>/installation
+# → returns installation `id` and `app_id` on success (200).
+```
+
+Org-scoped installs with `repository_selection: selected` share one
+installation ID across all selected repos. Adding a repo to the selected
+set does not create a new installation — confirmed via the Boltz install
+(ID `125975574` covers `studio-framework`, `battlebrotts-v2`, and
+`studio-audits`).
+
+### 3. Write the private key
+
+Download the `.pem` from the App settings page ("Private keys" → "Generate
+a private key"). Write it to the workspace host:
+
+```bash
+mv ~/Downloads/brott-studio-<agent>.<date>.private-key.pem \
+   ~/.config/gh/brott-studio-<agent>-app.pem
+chmod 0600 ~/.config/gh/brott-studio-<agent>-app.pem
+```
+
+Never commit the PEM. Never paste its contents into prompts, announce
+events, or chat messages. The token-mint helpers read it directly at
+mint-time.
+
+### 4. Verify via token mint
+
+Add or reuse a mint helper at `~/bin/<agent>-gh-token` (see existing
+`~/bin/{specc,optic,boltz}-gh-token` for the canonical PyJWT-based
+implementation). Smoke test:
+
+```bash
+BOLTZ_APP_ID=3459519 BOLTZ_INSTALLATION_ID=125975574 \
+    ~/bin/boltz-gh-token | wc -c
+# expect ≈ 40 chars + newline, exit 0
+```
+
+A successful mint returns a short-lived installation access token
+(`ghs_...`, 40-character prefix plus payload). Non-zero exit or a
+non-token response indicates a misconfigured App ID, installation ID, PEM
+path, or repo access — chase those before wiring the App into any
+workflow.
+
+### 5. Wire into CI (project repos only)
+
+For Apps that power CI workflows (currently Boltz for `Audit Gate`), add
+the App ID and PEM contents as repo-level Actions secrets on each project
+repo that needs them:
+
+- `<AGENT>_APP_ID` — numeric App ID.
+- `<AGENT>_APP_PRIVATE_KEY` — full PEM contents (CR-LF preserved).
+
+Create via the REST API with libsodium sealed-box encryption (see
+[API docs](https://docs.github.com/en/rest/actions/secrets)); never commit
+the PEM and never echo it in a workflow log.
 
 ---
 


### PR DESCRIPTION
## Summary

Two self-sufficiency docs from S18.2 bundled into one reviewable PR:

- **[S18.2-007]** New `BOOTSTRAP_NEW_PROJECT.md` at framework root. 5 ordered steps for standing up a new project under the studio pipeline: create repo → provision per-agent Apps → wire secrets + CI gates → point framework at new project → first-arc kickoff. Target bar: a cold-start agent can run it without blocking questions. (No cold-start validation this sprint — that's S18.3.)
- **[S18.2-008]** New `SECRETS.md` section `## Per-Agent GitHub App Bootstrap`. Covers org-level App creation (webhook disabled, min-permission table per role), install on target repo (web UI + API paths), PEM write (`0600`), and verify via token mint. Worked examples: Optic (App ID `3459479`, install `125974902`) and Boltz (App ID `3459519`, install `125975574`).

Arc: **S18 Framework Hardening**, sub-sprint **S18.2**.

## Inventory update ([S18.2-001] finding)

Also updated the Boltz App inventory entry in `SECRETS.md`. Task brief said "record the NEW studio-audits-scoped Boltz installation ID" — on verification, there is none. The Boltz App installation `125975574` is **org-level** (`brott-studio`) with `repository_selection: selected`, and the same installation ID covers `studio-framework`, `battlebrotts-v2`, AND `studio-audits` under the one install. `GET /repos/brott-studio/studio-audits/installation` returns `installation_id: 125975574`, `app_id: 3459519`. No separate studio-audits-scoped installation exists or is needed. Added a scope note to the Boltz entry to document this explicitly.

The App-level Contents permission is `write`; effective usage against `studio-audits` is **read-only** — enforced by the `Audit Gate` workflow logic (`audit_gate.py` only issues GETs). The task brief mentioned `Contents: Read-only` for the studio-audits install, but App permissions are set App-wide in GitHub — not per-installation — so we rely on workflow-logic scoping rather than installation-level restriction.

## Cross-references

- `BOOTSTRAP_NEW_PROJECT.md` §2 links to `SECRETS.md §Per-Agent GitHub App Bootstrap`.
- `SECRETS.md` §Per-Agent GitHub App Bootstrap cross-references `BOOTSTRAP_NEW_PROJECT.md §2`.

## Out of scope

- Cold-start validation protocol (S18.3).
- Branch-protection tightening (`enforce_admins`, `restrictions`, bypass) — S18.4. `BOOTSTRAP_NEW_PROJECT.md §3` explicitly defers these.

## Secret hygiene

`grep -rE (ghp_|github_pat_|x-access-token:|BEGIN RSA PRIVATE|BEGIN PRIVATE KEY) . --exclude-dir=.git` → only pre-existing doc-string matches in `SECRETS.md`/`SPAWN_PROTOCOL.md` (literal `x-access-token:${PAT}` templating in example clone commands). No new secret-shaped content introduced by this PR. PEM bytes never entered the repo — the docs reference paths + App IDs only.
