### PR TITLE
[S18.4-003] docs: reflect S18.4 structural gates in framework docs

### DIFF
--- a/FRAMEWORK.md
+++ b/FRAMEWORK.md
@@ -241,6 +241,8 @@ Every rule in this framework is tagged **[Structural]** or **[Compliance-reliant
 | Tests must pass | CI gate on PR | [Structural] |
 | PR review required | Branch protection | [Structural] |
 | Visual verification | Playwright in pipeline | [Structural] |
+| `Optic Verified` check-run on PRs | `optic-verified.yml` producer workflow (S18.4-001) posts binary success/failure check-run from the Optic App; required status check on `main` | [Structural — enforced] |
+| Admin-PAT bypass closure | `enforce_admins: true` on `brott-studio/battlebrotts-v2:main` (S18.4-002); admin-override path removed — every PR must pass all required contexts + reviews | [Structural — enforced] |
 | Agent logging | Git history IS the log (no separate log files needed) | [Structural] |
 | Dashboard freshness | Generated after sprint, not maintained live | [Structural] |
 | Sprint Specc gate | Riv + Ett + The Bott all check | [Compliance-reliant] |

--- a/agents/optic.md
+++ b/agents/optic.md
@@ -74,6 +74,8 @@ After local verify completes (PASS or FAIL), Optic posts a GitHub check-run to t
 - **Timing:** fires AFTER local verify produces its verdict, BEFORE Optic returns to Riv. The check-run is part of the verify stage, not an afterthought.
 - **Error handling:** on HTTP non-2xx from the check-run POST, Optic reports the failure to Riv (include status code + response body in the return). Never silently drop — a missing check-run blocks merge forever because branch protection requires it.
 
+**Producer implementation:** `.github/workflows/optic-verified.yml` on `brott-studio/battlebrotts-v2` (since S18.4-001). Triggers on `Verify` workflow completion via `workflow_run`. Mints an App installation token for the Optic App (app_id 3459479, installation 125974902), computes binary conclusion from Verify's result, and POSTs the `Optic Verified` check-run. See [S18.4-001] audit for full architecture.
+
 ## What You Don't Do
 - Write game code (that's Nutts)
 - Design balance changes (that's Gizmo — you provide data, Gizmo decides)


### PR DESCRIPTION
## [S18.4-003] Framework docs: reflect S18.4 structural gates

Close-out docs for S18.4. Two small edits, no behavioral changes.

### Changes

1. **`agents/optic.md` §"Check-run posting"** — adds a "Producer implementation" block cross-referencing the live `optic-verified.yml` workflow on `brott-studio/battlebrotts-v2` (shipped in [S18.4-001]). Documents the `workflow_run` trigger, App-token auth (app_id 3459479, installation 125974902), and binary conclusion computation.

2. **`FRAMEWORK.md` §"Enforcement Mechanisms"** — flips the status of `Optic Verified` and `enforce_admins` closure from implied/paper-tiger to **[Structural — enforced]**, reflecting:
   - [S18.4-001]: Optic producer workflow live and posting check-runs.
   - [S18.4-002]: `enforce_admins: true` applied to `brott-studio/battlebrotts-v2:main`; admin-override path retired.

### Arc context

S18.4 close-out. Companion PRs:
- `brott-studio/battlebrotts-v2` — README polish (proof-of-gate PR, end-to-end validates the now-fully-enforced branch protection).
- `brott-studio/battlebrotts-v2` — `sprints/sprint-18.2.md` Option A ledger close-out entry for PR #233.

Prior merged work in this sub-sprint (for Specc's S18.4 audit):
- [S18.4-001] (PR #233 on `battlebrotts-v2`, merged `7e16b95c`) — Optic producer workflow.
- [S18.4-002a] (PR #236 on `battlebrotts-v2`) — Audit Gate short-circuit fix.
- [S18.4-002] (PR #234 on `battlebrotts-v2`) — `enforce_admins: true` applied.

Scope-gate: touches only `agents/optic.md` and `FRAMEWORK.md`.

Restrictions hardening (ref #225 on `battlebrotts-v2`) remains deferred to S18.5.