### PR TITLE
S19.3: add write-phase sentinel (Proposal 3.1, Approach 3)

### DIFF
--- a/FRAMEWORK.md
+++ b/FRAMEWORK.md
@@ -148,6 +148,21 @@ Secrets handling (PAT authentication) is configured via a credential helper — 
 
 ---
 
+## Interrupt Safety — Write-Phase Sentinel
+
+Write-phase subagents (**Specc**, **Nutts**, **Boltz**) MUST include the canonical write-phase sentinel block in their role profile and execute it as the first tool call of every spawn. The sentinel latches per-session first-entry and causes resumed sessions (OpenClaw `subagent-orphan-recovery`) to exit cleanly without re-executing write operations.
+
+**Roles required to include it:** Specc, Nutts, Boltz.
+**Roles forbidden from including it:** Riv, Ett, Gizmo, Optic. Orchestration and verification roles are re-executable on resume by design — latching them would block legitimate continuation.
+
+**Verification:** Optic's role-profile-integrity check verifies the sentinel block is present in all write-phase profiles and absent in orchestrator/verifier profiles. See `agents/optic.md`.
+
+**Origin:** Proposal 3.1 (`memory/2026-04-22-phase2-phase3-proposals.md`), implemented in S19.3 (`audits/battlebrotts-v2/v2-sprint-19.3.md`).
+
+**Contract details:** see the boilerplate in `agents/specc.md`, `agents/nutts.md`, or `agents/boltz.md`.
+
+---
+
 ## Verification Strategy
 
 ### Layer 1: Automated Tests (CI)

--- a/agents/boltz.md
+++ b/agents/boltz.md
@@ -7,6 +7,61 @@
 - **Secrets:** PAT at `~/.config/gh/brott-studio-token`. Never paste in prompts or commit messages. See [../SECRETS.md](../SECRETS.md).
 - **Framework:** Read [../FRAMEWORK.md](../FRAMEWORK.md), [../PIPELINE.md](../PIPELINE.md), and this profile every spawn. State lives in files.
 
+## Interrupt Safety — Write-Phase Sentinel
+
+**Mandatory for this role.** Before any write-phase operation (git add/commit/push, `gh` mutating API call, file write outside the scratch working tree, ICS write, SMTP send), run the sentinel check below as your **first tool call**.
+
+**Rationale:** OpenClaw's `subagent-orphan-recovery` re-enters this session on gateway restart with a synthetic "continue where you left off" message. Without this latch, a resumed turn can re-execute write-phase operations (duplicate commits, duplicate PRs, overwritten audits). This pattern makes re-entry a clean no-op. See [FRAMEWORK.md § Interrupt Safety — Write-Phase Sentinel](../FRAMEWORK.md#interrupt-safety--write-phase-sentinel) and `memory/2026-04-22-phase1-root-cause.md` for origin.
+
+**Parse your session ID** from the Session Context injected into your system prompt. The line reads `Your session: agent:main:subagent:<SESSION_ID>`. Extract the UUID after the final colon.
+
+**Run this block first (exec tool):**
+
+```bash
+SESSION_ID="<parsed-from-session-context>"
+SENTINEL_DIR="$HOME/.openclaw/subagents/${SESSION_ID}"
+SENTINEL="${SENTINEL_DIR}/write-phase-entered.sentinel"
+ROLE="boltz"   # <-- set per profile: specc | nutts | boltz
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$SENTINEL_DIR"
+
+if [[ -f "$SENTINEL" ]]; then
+  FIRST_ENTRY_AT="$(cat "$SENTINEL" 2>/dev/null || echo 'unknown')"
+  printf '{"event":"write-phase-sentinel","outcome":"resume-declined","sessionId":"%s","role":"%s","ts":"%s","sentinel":"%s","firstEntryAt":"%s"}\n' \
+    "$SESSION_ID" "$ROLE" "$NOW" "$SENTINEL" "$FIRST_ENTRY_AT"
+  exit 42
+else
+  printf '%s\n' "$NOW" > "$SENTINEL"
+  printf '{"event":"write-phase-sentinel","outcome":"first-entry","sessionId":"%s","role":"%s","ts":"%s","sentinel":"%s"}\n' \
+    "$SESSION_ID" "$ROLE" "$NOW" "$SENTINEL"
+fi
+```
+
+**Branching rules:**
+
+- **Exit 42** → sentinel was present; write phase already entered in a prior turn of this session. **Immediately stop all tool work.** Do not clone, do not edit files, do not call `gh`, do not push. Emit the resume-decline structured payload (below) as your final task output to your parent.
+- **Exit 0 (fell through)** → first entry. Proceed with your normal task.
+
+**Resume-decline exit payload** (final task output):
+
+```json
+{
+  "status": "resumed-declined",
+  "role": "<specc|nutts|boltz>",
+  "sessionId": "<session UUID>",
+  "firstEntryAt": "<ISO ts from sentinel>",
+  "declinedAt": "<ISO ts now>",
+  "reason": "Write-phase sentinel present — prior execution of this session already entered write phase. Declining re-execution to prevent duplicate side effects.",
+  "recommendation": "Parent should treat original task as interrupted. If the intended artifact cannot be verified as landed, parent should spawn a fresh subagent to retry. Do not re-resume this session."
+}
+```
+
+**Do not:**
+- Delete the sentinel at any point. One-shot per-session latch.
+- Skip the sentinel because "this task is small." Every write-phase action in this role is gated by it.
+- Re-run the sentinel block mid-task. One invocation per session, at the top, full stop.
+
 ## Role
 REVIEW stage of the pipeline. Reviews all PRs via GitHub App before merge. The quality gate.
 

--- a/agents/nutts.md
+++ b/agents/nutts.md
@@ -7,6 +7,61 @@
 - **Secrets:** PAT at `~/.config/gh/brott-studio-token`. Never paste in prompts, URLs, or commit messages. See [../SECRETS.md](../SECRETS.md).
 - **Framework:** Read [../FRAMEWORK.md](../FRAMEWORK.md), [../PIPELINE.md](../PIPELINE.md), and this profile every spawn. State lives in files.
 
+## Interrupt Safety — Write-Phase Sentinel
+
+**Mandatory for this role.** Before any write-phase operation (git add/commit/push, `gh` mutating API call, file write outside the scratch working tree, ICS write, SMTP send), run the sentinel check below as your **first tool call**.
+
+**Rationale:** OpenClaw's `subagent-orphan-recovery` re-enters this session on gateway restart with a synthetic "continue where you left off" message. Without this latch, a resumed turn can re-execute write-phase operations (duplicate commits, duplicate PRs, overwritten audits). This pattern makes re-entry a clean no-op. See [FRAMEWORK.md § Interrupt Safety — Write-Phase Sentinel](../FRAMEWORK.md#interrupt-safety--write-phase-sentinel) and `memory/2026-04-22-phase1-root-cause.md` for origin.
+
+**Parse your session ID** from the Session Context injected into your system prompt. The line reads `Your session: agent:main:subagent:<SESSION_ID>`. Extract the UUID after the final colon.
+
+**Run this block first (exec tool):**
+
+```bash
+SESSION_ID="<parsed-from-session-context>"
+SENTINEL_DIR="$HOME/.openclaw/subagents/${SESSION_ID}"
+SENTINEL="${SENTINEL_DIR}/write-phase-entered.sentinel"
+ROLE="nutts"   # <-- set per profile: specc | nutts | boltz
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$SENTINEL_DIR"
+
+if [[ -f "$SENTINEL" ]]; then
+  FIRST_ENTRY_AT="$(cat "$SENTINEL" 2>/dev/null || echo 'unknown')"
+  printf '{"event":"write-phase-sentinel","outcome":"resume-declined","sessionId":"%s","role":"%s","ts":"%s","sentinel":"%s","firstEntryAt":"%s"}\n' \
+    "$SESSION_ID" "$ROLE" "$NOW" "$SENTINEL" "$FIRST_ENTRY_AT"
+  exit 42
+else
+  printf '%s\n' "$NOW" > "$SENTINEL"
+  printf '{"event":"write-phase-sentinel","outcome":"first-entry","sessionId":"%s","role":"%s","ts":"%s","sentinel":"%s"}\n' \
+    "$SESSION_ID" "$ROLE" "$NOW" "$SENTINEL"
+fi
+```
+
+**Branching rules:**
+
+- **Exit 42** → sentinel was present; write phase already entered in a prior turn of this session. **Immediately stop all tool work.** Do not clone, do not edit files, do not call `gh`, do not push. Emit the resume-decline structured payload (below) as your final task output to your parent.
+- **Exit 0 (fell through)** → first entry. Proceed with your normal task.
+
+**Resume-decline exit payload** (final task output):
+
+```json
+{
+  "status": "resumed-declined",
+  "role": "<specc|nutts|boltz>",
+  "sessionId": "<session UUID>",
+  "firstEntryAt": "<ISO ts from sentinel>",
+  "declinedAt": "<ISO ts now>",
+  "reason": "Write-phase sentinel present — prior execution of this session already entered write phase. Declining re-execution to prevent duplicate side effects.",
+  "recommendation": "Parent should treat original task as interrupted. If the intended artifact cannot be verified as landed, parent should spawn a fresh subagent to retry. Do not re-resume this session."
+}
+```
+
+**Do not:**
+- Delete the sentinel at any point. One-shot per-session latch.
+- Skip the sentinel because "this task is small." Every write-phase action in this role is gated by it.
+- Re-run the sentinel block mid-task. One invocation per session, at the top, full stop.
+
 ## Role
 BUILD stage of the pipeline. Writes game code AND tests together.
 

--- a/agents/specc.md
+++ b/agents/specc.md
@@ -305,6 +305,61 @@ Optic's Task 4 simulation: run Tests 2 and 3 against a real existing
 audit (S17.4 or S18.1). Test 1 can be stubbed or run against a
 short-lived throwaway sub-sprint slug in a branch, then reverted.
 
+## Interrupt Safety — Write-Phase Sentinel
+
+**Mandatory for this role.** Before any write-phase operation (git add/commit/push, `gh` mutating API call, file write outside the scratch working tree, ICS write, SMTP send), run the sentinel check below as your **first tool call**.
+
+**Rationale:** OpenClaw's `subagent-orphan-recovery` re-enters this session on gateway restart with a synthetic "continue where you left off" message. Without this latch, a resumed turn can re-execute write-phase operations (duplicate commits, duplicate PRs, overwritten audits). This pattern makes re-entry a clean no-op. See [FRAMEWORK.md § Interrupt Safety — Write-Phase Sentinel](../FRAMEWORK.md#interrupt-safety--write-phase-sentinel) and `memory/2026-04-22-phase1-root-cause.md` for origin.
+
+**Parse your session ID** from the Session Context injected into your system prompt. The line reads `Your session: agent:main:subagent:<SESSION_ID>`. Extract the UUID after the final colon.
+
+**Run this block first (exec tool):**
+
+```bash
+SESSION_ID="<parsed-from-session-context>"
+SENTINEL_DIR="$HOME/.openclaw/subagents/${SESSION_ID}"
+SENTINEL="${SENTINEL_DIR}/write-phase-entered.sentinel"
+ROLE="specc"   # <-- set per profile: specc | nutts | boltz
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$SENTINEL_DIR"
+
+if [[ -f "$SENTINEL" ]]; then
+  FIRST_ENTRY_AT="$(cat "$SENTINEL" 2>/dev/null || echo 'unknown')"
+  printf '{"event":"write-phase-sentinel","outcome":"resume-declined","sessionId":"%s","role":"%s","ts":"%s","sentinel":"%s","firstEntryAt":"%s"}\n' \
+    "$SESSION_ID" "$ROLE" "$NOW" "$SENTINEL" "$FIRST_ENTRY_AT"
+  exit 42
+else
+  printf '%s\n' "$NOW" > "$SENTINEL"
+  printf '{"event":"write-phase-sentinel","outcome":"first-entry","sessionId":"%s","role":"%s","ts":"%s","sentinel":"%s"}\n' \
+    "$SESSION_ID" "$ROLE" "$NOW" "$SENTINEL"
+fi
+```
+
+**Branching rules:**
+
+- **Exit 42** → sentinel was present; write phase already entered in a prior turn of this session. **Immediately stop all tool work.** Do not clone, do not edit files, do not call `gh`, do not push. Emit the resume-decline structured payload (below) as your final task output to your parent.
+- **Exit 0 (fell through)** → first entry. Proceed with your normal task.
+
+**Resume-decline exit payload** (final task output):
+
+```json
+{
+  "status": "resumed-declined",
+  "role": "<specc|nutts|boltz>",
+  "sessionId": "<session UUID>",
+  "firstEntryAt": "<ISO ts from sentinel>",
+  "declinedAt": "<ISO ts now>",
+  "reason": "Write-phase sentinel present — prior execution of this session already entered write phase. Declining re-execution to prevent duplicate side effects.",
+  "recommendation": "Parent should treat original task as interrupted. If the intended artifact cannot be verified as landed, parent should spawn a fresh subagent to retry. Do not re-resume this session."
+}
+```
+
+**Do not:**
+- Delete the sentinel at any point. One-shot per-session latch.
+- Skip the sentinel because "this task is small." Every write-phase action in this role is gated by it.
+- Re-run the sentinel block mid-task. One invocation per session, at the top, full stop.
+
 ## Output
 
 Always include a full ISO timestamp in the audit header: `**Date:** YYYY-MM-DDTHH:MMZ` (UTC). This is used for dashboard sorting.


### PR DESCRIPTION
## Summary

Adds the canonical **write-phase sentinel** boilerplate to the three write-phase role profiles (Specc, Nutts, Boltz) and a corresponding framework-level section to `FRAMEWORK.md`. This closes the orphan-recovery duplicate-side-effect failure mode documented in Phase 1 of the orphan-recovery arc.

## Why

OpenClaw's `subagent-orphan-recovery` re-enters a subagent session on gateway restart by injecting a synthetic "continue where you left off" message into the same session. Without a latch, a resumed turn can re-execute write-phase operations — duplicate commits, duplicate PRs, overwritten audits. This is the failure mode that silently burned S18.3's Specc audit slot for ~9 hours.

Approach 3 (agent-profile sentinel) was chosen over Approach 1/2 to avoid upstream OpenClaw changes. Proposal 3.1 was ratified as the design; this PR is its implementation.

## What

On first entry to a write-phase subagent session, the sentinel block (executed as the first tool call) writes a marker file at `$HOME/.openclaw/subagents/<sessionId>/write-phase-entered.sentinel` and falls through. On any subsequent entry (same sessionId, i.e. the orphan-recovery synthetic resume), the block sees the existing marker and `exit 42`s; the model then emits a structured `status: "resumed-declined"` payload to its parent instead of re-executing the task. Re-entry becomes a clean no-op.

**Gated (sentinel required):** Specc, Nutts, Boltz.
**NOT gated (intentional):** Riv, Ett, Gizmo, Optic. Orchestration and verification roles are re-executable on resume by design — latching them would block legitimate continuation.

## Changes

- `agents/specc.md` — adds `## Interrupt Safety — Write-Phase Sentinel` H2 after the `## Pre-Commit Verification (Audit Idempotency)` section (ROLE=specc).
- `agents/nutts.md` — adds the same H2 immediately after `## Core Rules` (ROLE=nutts).
- `agents/boltz.md` — adds the same H2 immediately after `## Core Rules` (ROLE=boltz).
- `FRAMEWORK.md` — adds `## Interrupt Safety — Write-Phase Sentinel` section between `## Agent Spawn Protocol` and `## Verification Strategy`, with anchor `#interrupt-safety--write-phase-sentinel`.

## Source of truth

- **Design spec (T1):** `memory/2026-04-23-s19.3-t1-gizmo-sentinel-spec.md` (Gizmo) — canonical boilerplate is §5, FRAMEWORK.md section content is §6. Pasted verbatim into the three profiles; only `ROLE=` value adjusted per file.
- **Arc brief:** `memory/2026-04-22-arc-brief-orphan-recovery.md`.
- **Phase 1 root cause:** `memory/2026-04-22-phase1-root-cause.md`.

## Follow-on work (NOT in this PR)

- Riv profile update to handle `status: "resumed-declined"` events per Gizmo spec §4 (expected S19.4 carry-forward).
- Optic role-profile-integrity check that verifies the sentinel block is present in gated profiles and absent in non-gated profiles.

## Deviations from T1 spec

**Label taxonomy mismatch.** Task brief requested labels `area/compliance`, `prio/P1`, `arc/orphan-recovery`. The studio-framework label set uses `area:*` / `prio:*` naming (colons, not slashes), and none of `area/compliance`, `prio/P1`, `arc/orphan-recovery` exist. Substituted existing labels: `area:framework`, `prio:P2` (no P1 exists), `enhancement`. Flagging to Riv for disposition. No other deviations from Gizmo's spec.

## Verification

- [x] Sentinel block pasted verbatim into all three profiles
- [x] `ROLE=` value correctly set per file (specc / nutts / boltz)
- [x] FRAMEWORK.md anchor is `#interrupt-safety--write-phase-sentinel`
- [x] Labels non-empty at PR creation time
- [x] Branch: `s19.3/orphan-resume-sentinel`
- [ ] Boltz review + merge (T4)

## Meta

Do not merge — T4 (Boltz review) is the gate.
