### PR TITLE
[S20.2-001] H3 Riv-state durability: task-ledger + reconciler sprintShape [sprint-20.2]

### DIFF
--- a/FRAMEWORK.md
+++ b/FRAMEWORK.md
@@ -277,6 +277,13 @@ Full detail: [REPO_MAP.md](REPO_MAP.md).
 | `brott-studio/<project-repo>` | The Bott | Game code, GDD, KB, dashboard, sprint history |
 | `brott-studio/studio-audits` | Specc | Audit reports, independent from project |
 
+### Workspace State (runtime, not in git)
+
+Some agents maintain durable runtime state in the workspace, outside any repo. These files are not committed; they are per-host operational state.
+
+- `memory/active-arcs.json` — runtime ledger of in-flight arcs. Written by The Bott and Riv; read by the active-arc reconciler watchdog. See [docs/active-arc-reconciler.md](docs/active-arc-reconciler.md).
+- `memory/sprint-state/<arc>/<sprint>.json` — per-sub-sprint durable task-ledger used by Riv for resume-safe orchestration. Records every task Riv has spawned and its current state so a respawned Riv can resume cleanly after OOM/end. Schema: [schemas/sprint-state-ledger.md](schemas/sprint-state-ledger.md).
+
 ---
 
 ## Enforcement Mechanisms

--- a/agents/riv.md
+++ b/agents/riv.md
@@ -146,6 +146,100 @@ Before spawning Gizmo on sprint ≥ 2 of the arc, verify Specc's audit file for 
 - If no audit file → flag error, do NOT proceed to the next sprint. Report to The Bott.
 - If audit file present → loop back to Phase 0 (the audit-gate check at the top of the next sprint will re-confirm before Gizmo spawns).
 
+## Task-Ledger Protocol (S20.2 H3)
+
+Riv maintains a **per-sub-sprint durable task-ledger** so a respawned Riv (after OOM, gateway restart, or run-mode end) can reconstruct what has already been done and resume cleanly.
+
+**Ledger location:** `~/.openclaw/workspace/memory/sprint-state/<arc-name>/<sub-sprint>.json`
+**Schema:** [../schemas/sprint-state-ledger.md](../schemas/sprint-state-ledger.md) (canonical). Current `schemaVersion: 1`.
+
+### When Riv writes to the ledger
+
+- **On sprint-plan ingest from Ett:** write top-level fields (`arc`, `subSprint`, `sprintPlanRef`, `rivSessionKey`, `createdAt`, `updatedAt`, `schemaVersion: 1`) and an initial `pending` entry for each task in Ett's plan.
+- **At each task boundary:**
+  - `pending → spawned` on `sessions_spawn` (record `startedAt`, `childSessionKey`).
+  - `spawned → in-flight` (optional, on observable progress signal).
+  - `{spawned|in-flight} → completed` on child completion event **AND** artifact verification (set `childCompletionEvent: true`, `artifactRef`, `endedAt`).
+  - `{spawned|in-flight} → failed` on error or artifact-verification failure (set `lastError`, `endedAt`).
+  - `{spawned|in-flight} → declined` on an orphan-resume-declined payload from the child.
+- **On sub-sprint close:** write final `updatedAt` and leave the file in place (archival).
+
+### Ledger read (respawn-Riv startup)
+
+Respawn-Riv's **first tool call after reading the arc brief** is to check `memory/sprint-state/<arc>/<sub-sprint>.json`:
+
+1. If the file doesn't exist → fresh sprint, proceed normally.
+2. Read `schemaVersion`. If `> 1` → escalate to Bott with the `RIV-SCHEMA-GUARD` payload (see schema doc); do **not** attempt to interpret the ledger.
+3. Walk `tasks[]` in order and apply the **respawn decision table** (schema doc § Respawn Decision Table):
+   - `completed` → skip.
+   - `pending` → spawn now.
+   - `spawned` / `in-flight` with `artifactRef` present → verify artifact in source-of-truth (GitHub Contents API for PRs/audits; filesystem for workspace docs). If present → mark `completed`, skip. If absent → respawn, increment `attemptCount`.
+   - `spawned` / `in-flight` with `artifactRef` null → respawn, increment `attemptCount`.
+   - `failed` → respawn if `attemptCount < 3`; else escalate to Bott.
+   - `declined` → **always escalate to Bott, never auto-respawn.**
+4. If any task has `attemptCount > 3` → escalate to Bott, do not auto-respawn.
+
+### Atomic-write implementation
+
+All ledger writes are atomic and serialized via a sibling lock file. Shell idiom:
+
+```bash
+ledger="$HOME/.openclaw/workspace/memory/sprint-state/$ARC/$SUB.json"
+lock="$ledger.lock"
+mkdir -p "$(dirname "$ledger")"
+touch "$lock"
+
+(
+  flock -x 9
+
+  current='{}'
+  [[ -f "$ledger" ]] && current=$(cat "$ledger")
+
+  # ... jq mutation producing $updated ...
+
+  tmp="$ledger.tmp.$$.$RANDOM"
+  printf '%s\n' "$updated" > "$tmp"
+  sync "$tmp"
+  mv -f "$tmp" "$ledger"
+) 9>"$lock"
+```
+
+The lock file is **sibling**, not the data file itself — opening the data file for flock would race with the rename step.
+
+### Resume-declined handler
+
+When Riv's own resume-on-interrupt returns declined (write-phase sentinel present on Riv itself, or harness-block), Riv writes a synthetic ledger entry:
+
+```json
+{
+  "task": "riv-resume-declined",
+  "taskType": "riv",
+  "status": "declined",
+  "startedAt": "<resume attempt ts>",
+  "endedAt": "<same>",
+  "childSessionKey": "<orphan Riv session key>",
+  "childCompletionEvent": false,
+  "artifactRef": null,
+  "attemptCount": 1,
+  "lastError": "<sentinel-present | harness-block | ...>",
+  "notes": "Riv resume-on-interrupt declined; arc paused for Bott review"
+}
+```
+
+And returns as its final spawn output the structured `RIV-RESUME-DECLINED` payload:
+
+```
+RIV-RESUME-DECLINED
+arc: <arc-name>
+subSprint: <sub-sprint>
+ledgerPath: memory/sprint-state/<arc>/<sub-sprint>.json
+declinedReason: <reason>
+lastCompletedTask: <task name or "none">
+recommendedAction: <"respawn-fresh-Riv" | "escalate-to-HCD" | "manual-inspection">
+```
+
+The Bott (spawning session) handles the escalation. Riv does **not** post to Discord channels (existing HARD RULE — see COMMS.md).
+
 ## What You Don't Do
 - Plan sprints (Ett does that)
 - Write code (Nutts does that)

--- a/docs/active-arc-reconciler.md
+++ b/docs/active-arc-reconciler.md
@@ -1,0 +1,97 @@
+# Active-Arc Reconciler
+
+**Type:** Watchdog (workspace-local cron job).
+**Script location:** `~/.openclaw/workspace/scripts/active-arc-reconciler.sh` (workspace-local, **not** tracked in this repo).
+**Cron cadence:** every 30 min.
+**Origin:** S18.3 silent-outage postmortem (see `SOUL.md` \u00a7 Long-running arc verification) + S20.2 `sprintShape` extension.
+
+## Purpose
+
+For each arc in `~/.openclaw/workspace/memory/active-arcs.json`, verify that the sub-sprint currently in flight has either:
+
+- **Structurally closed** (the expected artifact exists in its source-of-truth), OR
+- **Is still legitimately in-progress** (recent `lastReportedAt`, no artifact yet).
+
+When neither is true, emit an alert so The Bott can intervene instead of discovering the outage hours later. Artifact-based verification is the canonical close-out signal, **not** completion-event propagation, because multi-level subagent spawns can silently drop events between levels.
+
+## Data Contract
+
+### `active-arcs.json` \u2014 per-arc fields the reconciler reads
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Arc display name. |
+| `currentSubSprint` | string | yes | String containing the current sub-sprint id (e.g. `"S18.3 (Phase 3 build)"`, `"S20.2 in flight"`). The reconciler extracts `S<N>.<M>` via regex. |
+| `sprintShape` | enum \| absent | no | One of `"build"` / `"spike"` / `"infra"`. Default `"build"` when absent (backward-compatible). Describes the expected-artifact shape for the **current** sub-sprint; rewrite on sub-sprint boundary. See table below. |
+| `lastReportedAt` | ISO-8601 | yes | When the arc was last reported on. Staleness is computed from this. |
+| `lastReportedEvent` | string | yes | Free-form last-event text; scanned for close-out markers (`grade`, `closed`, `A-`, `A\u2212`, `B+`, `CLOSED`). |
+
+### `sprintShape` values
+
+| Value | Expected artifact | Source of truth | API/check |
+|---|---|---|---|
+| `"build"` (default) | Audit file at `audits/<project>/v2-sprint-<N>.<M>.md` on `studio-audits/main` | GitHub Contents API | `GET /repos/brott-studio/studio-audits/contents/<path>?ref=main` |
+| `"spike"` | Ops doc matching `memory/ops/<N.M>-*.md` in the workspace | Workspace filesystem | `ls ~/.openclaw/workspace/memory/ops/<N.M>-*.md` |
+| `"infra"` | Same as `"build"` \u2014 audit on `studio-audits/main` | GitHub Contents API | `GET /repos/brott-studio/studio-audits/contents/<path>?ref=main` |
+
+`"infra"` is a distinct taxonomy value (not merged into `"build"`) so dashboards and future logic can treat infrastructure sub-sprints differently even though the current artifact location is identical.
+
+## Alert Classes
+
+| Class | Trigger | Action expected |
+|---|---|---|
+| `closed-unreported` | Artifact exists in source-of-truth **AND** `lastReportedEvent` does not contain a close-out marker. | The Bott updates `active-arcs.json.lastReportedEvent` and pings the studio channel with grade + carry-forwards. |
+| `stale-no-artifact` | Artifact absent **AND** `lastReportedAt` older than the staleness window. | The Bott inspects the Riv subtree (`subagents list`), checks the retired Riv's final state, respawns Specc-audit directly if needed (see S18.3 retry pattern). |
+| `api-error-<code>` | GitHub API returned non-200/404 (only for `build`/`infra`). | Usually self-heals next cycle. If persistent, investigate token/auth. |
+
+## Staleness Window
+
+**45 minutes.** Sub-sprint close-out normally happens in 40\u2013150 min; 45 min mid-build without progress is within normal noise, but >45 min **with no artifact landed** is real signal.
+
+## Alert Dedupe (Cooldown)
+
+Alerts for the same `(arc, status)` pair are suppressed within `COOLDOWN_MINUTES` (default 180 = 3h). Cooldown state lives in `~/.openclaw/workspace/memory/arc-reconciler-cooldown.json`. This prevents the 30-min cron from pinging the channel every cycle while an outage is being diagnosed.
+
+## Exit Codes
+
+- `0` \u2014 all arcs healthy (in-progress or closed cleanly), OR alerts suppressed by cooldown.
+- `2` \u2014 at least one arc has an alert-worthy discrepancy that was **not** suppressed.
+
+## Example `active-arcs.json` Fragment
+
+```json
+{
+  "activeArcs": [
+    {
+      "name": "S20 Hardening Arc",
+      "currentSubSprint": "S20.2 (H3 in flight)",
+      "sprintShape": "build",
+      "lastReportedAt": "2026-04-23T13:10:00Z",
+      "lastReportedEvent": "S20.2 H3 Nutts spawned"
+    },
+    {
+      "name": "Orphan-Recovery Durability Arc",
+      "currentSubSprint": "S19.5 (ops-only spike)",
+      "sprintShape": "spike",
+      "lastReportedAt": "2026-04-22T20:58:00Z",
+      "lastReportedEvent": "S19.5 spike in progress; ops doc pending"
+    }
+  ]
+}
+```
+
+In the first entry, the reconciler queries GitHub for `audits/battlebrotts-v2/v2-sprint-20.2.md` on `studio-audits/main`. In the second, it globs `~/.openclaw/workspace/memory/ops/19.5-*.md`.
+
+## Manual Invocation
+
+```bash
+bash ~/.openclaw/workspace/scripts/active-arc-reconciler.sh | jq .
+```
+
+Exit 0 = healthy; exit 2 = alert. JSON output is always emitted to stdout regardless.
+
+## See Also
+
+- `SOUL.md` \u00a7 Long-running arc verification \u2014 why artifact-based verification beats event propagation.
+- `schemas/sprint-state-ledger.md` \u2014 Riv's per-sub-sprint task-ledger, which complements this watchdog at the orchestration layer.
+- `FRAMEWORK.md` \u00a7 Repo Structure \u2192 Workspace State \u2014 where `active-arcs.json` lives in the overall state model.

--- a/schemas/sprint-state-ledger.md
+++ b/schemas/sprint-state-ledger.md
@@ -1,0 +1,210 @@
+# Sprint-State Ledger Schema
+
+**Status:** Canonical (S20.2 H3). Schema version: `1`.
+
+## Purpose
+
+Durable per-sub-sprint task state for Riv. Records every task Riv has spawned (Gizmo, Ett, Nutts, Boltz, Optic, Specc) with its current state, so that a **respawned Riv** after OOM, gateway restart, or run-mode end can reconstruct what has already been done and resume cleanly from the next unfinished task.
+
+The ledger is the canonical answer to the question: "When Riv wakes up again, what does it know?" Without it, respawn-Riv has only the arc brief + sprint plan and must re-derive state from artifact scans — which is brittle and expensive.
+
+This is the implementation of FRAMEWORK.md Core Principle #4 ("State lives in files, not in memory") for the Riv orchestration layer.
+
+## Location
+
+```
+~/.openclaw/workspace/memory/sprint-state/<arc-name>/<sub-sprint>.json
+```
+
+- One file **per sub-sprint**, not per arc. S20.2 gets its own file; S20.3 gets its own.
+- `<arc-name>` is kebab-case, e.g. `s20-hardening`.
+- `<sub-sprint>` is lowercase, e.g. `s20.2`.
+- Example: `~/.openclaw/workspace/memory/sprint-state/s20-hardening/s20.2.json`.
+
+Sibling lock file (see Atomic Write below):
+```
+~/.openclaw/workspace/memory/sprint-state/<arc-name>/<sub-sprint>.json.lock
+```
+
+The ledger file is **workspace-local runtime state**. It is not committed to any repo. Archival happens implicitly: when a sub-sprint closes, the ledger file is left in place under `memory/sprint-state/<arc>/`.
+
+## Top-Level Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `schemaVersion` | int | yes | Always `1` in this revision. Respawn-Riv refuses to read a ledger with `schemaVersion > 1` and escalates to Bott (schema guard). |
+| `arc` | string | yes | Arc name, kebab-case (e.g. `"s20-hardening"`). |
+| `subSprint` | string | yes | Sub-sprint id (e.g. `"s20.2"`). |
+| `sprintPlanRef` | string | yes | Path or URL to Ett's sprint plan (e.g. `memory/ops/2026-04-23-s20.2-sprint-plan.md`). |
+| `rivSessionKey` | string | yes | The current Riv session writing the ledger. Rewritten on each respawn. |
+| `createdAt` | string | yes | ISO-8601 UTC timestamp of initial write. |
+| `updatedAt` | string | yes | ISO-8601 UTC timestamp of most recent write. |
+| `tasks` | `Task[]` | yes | Ordered list of all tasks in the sub-sprint. |
+
+## Per-Task Fields (`Task`)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `task` | string | yes | Deterministic identifier. Must be stable across respawns (e.g. `"T2-nutts-patch"`). |
+| `taskType` | enum | yes | One of: `gizmo`, `ett`, `nutts`, `boltz`, `optic`, `specc`, `riv`. |
+| `status` | enum | yes | One of: `pending`, `spawned`, `in-flight`, `completed`, `failed`, `declined`. |
+| `startedAt` | string \| null | yes | ISO-8601 UTC when Riv spawned the task; `null` until spawned. |
+| `endedAt` | string \| null | yes | ISO-8601 UTC when task reached terminal state; `null` otherwise. |
+| `childSessionKey` | string \| null | yes | Spawned child's `agent:main:subagent:<uuid>` key; `null` if not yet spawned. |
+| `childCompletionEvent` | bool | yes | `true` only when Riv received the auto-announce wake event from the child. Default `false`. |
+| `artifactRef` | string \| null | yes | PR URL, audit file path, or ops doc path that this task produces. `null` until verified. |
+| `attemptCount` | int | yes | Number of spawn attempts for this task. Default `1`; increments on respawn. |
+| `lastError` | string \| null | yes | Terminal-state error message if `status` is `failed` or `declined`; `null` otherwise. |
+| `notes` | string \| null | yes | Free-form notes from Riv (decisions made inline, manual overrides, etc.). |
+
+## State Machine
+
+```
+        ┌──────────┐
+        │ pending  │  (initial)
+        └────┬─────┘
+             │ sessions_spawn
+             ▼
+        ┌──────────┐
+        │ spawned  │
+        └────┬─────┘
+             │ (optional progress signal)
+             ▼
+        ┌──────────┐
+        │in-flight │
+        └────┬─────┘
+             │
+     ┌───────┼─────────┬────────────┐
+     ▼       ▼         ▼            ▼
+┌─────────┐┌──────┐ ┌────────┐
+│completed││failed│ │declined│
+└─────────┘└──────┘ └────────┘
+```
+
+**Transitions (terminal states reached from any non-terminal state):**
+
+- `pending → spawned` on `sessions_spawn` returning a child session key.
+- `spawned → in-flight` (optional) when a progress signal is observed (artifact partially built, subagent emits an intermediate status, etc.). Skipping this state is legal.
+- `{spawned, in-flight} → completed` on child completion event **AND** artifact verification (see Respawn Decision below).
+- `{spawned, in-flight} → failed` on error or artifact-verification failure.
+- `{spawned, in-flight} → declined` on an orphan-resume-declined payload from the child (write-phase sentinel tripped).
+
+Terminal states (`completed`, `failed`, `declined`) do not transition further in the same ledger entry. A bounded-respawn retry creates a **new attempt on the same task entry** (increments `attemptCount`, rewrites `startedAt`/`endedAt`/etc.) rather than appending a new row.
+
+## Respawn Decision Table
+
+When respawn-Riv reads the ledger at startup, it walks `tasks[]` in order and applies:
+
+| `status` | `artifactRef` | Action |
+|---|---|---|
+| `completed` | — | Skip; do not respawn. |
+| `pending` | — | Spawn now (fresh start). |
+| `spawned` | present | Verify artifact exists in source-of-truth (GitHub / workspace). If yes → mark `completed` in place, skip. |
+| `spawned` | null | Respawn; increment `attemptCount`. |
+| `in-flight` | present | Verify artifact exists. If yes → mark `completed`, skip. |
+| `in-flight` | null | Respawn; increment `attemptCount`. |
+| `failed` | — | Respawn if `attemptCount < 3`; else escalate to Bott. |
+| `declined` | — | **ALWAYS escalate to Bott.** Never auto-respawn. |
+
+**Attempt cap:** if any task has `attemptCount > 3`, respawn-Riv escalates to Bott and does **not** auto-respawn, regardless of status.
+
+## Atomic Write Pattern
+
+All writes to `<sub-sprint>.json` are atomic and serialized against concurrent writers.
+
+1. Acquire `flock(2)` on `<sub-sprint>.json.lock` (a separate sibling lock file). The lock file is created if absent.
+2. Read current ledger (`<sub-sprint>.json`) into memory. If absent, initialize.
+3. Mutate in memory.
+4. Write to `<sub-sprint>.json.tmp.<pid>.<rand>` in the same directory.
+5. `fsync(2)` the tmp file.
+6. `rename(2)` the tmp file onto `<sub-sprint>.json` (atomic on POSIX same-filesystem).
+7. Release the flock.
+
+**Shell idiom:**
+
+```bash
+ledger="$HOME/.openclaw/workspace/memory/sprint-state/$ARC/$SUB.json"
+lock="$ledger.lock"
+mkdir -p "$(dirname "$ledger")"
+touch "$lock"
+
+(
+  flock -x 9
+
+  current='{}'
+  [[ -f "$ledger" ]] && current=$(cat "$ledger")
+
+  # ... jq mutation producing $updated ...
+
+  tmp="$ledger.tmp.$$.$RANDOM"
+  printf '%s\n' "$updated" > "$tmp"
+  sync "$tmp"          # best-effort fsync in shell
+  mv -f "$tmp" "$ledger"
+) 9>"$lock"
+```
+
+The lock file is **sibling**, not the data file itself — opening the data file for flock would race with the rename step.
+
+## Schema-Version Guard
+
+Respawn-Riv reads `schemaVersion` first. If it exceeds the version Riv understands (currently `1`), Riv **does not attempt to interpret the ledger**. It escalates to Bott with:
+
+```
+RIV-SCHEMA-GUARD
+arc: <arc-name>
+subSprint: <sub-sprint>
+ledgerPath: memory/sprint-state/<arc>/<sub-sprint>.json
+observedSchemaVersion: <int>
+supportedSchemaVersion: 1
+recommendedAction: manual-inspection
+```
+
+Rationale: a newer ledger written by a future Riv carries semantics this Riv doesn't know. Forging ahead with a partial read would corrupt state.
+
+## Example
+
+```json
+{
+  "schemaVersion": 1,
+  "arc": "s20-hardening",
+  "subSprint": "s20.2",
+  "sprintPlanRef": "memory/ops/2026-04-23-s20.2-sprint-plan.md",
+  "rivSessionKey": "agent:main:subagent:abcd-1234-...",
+  "createdAt": "2026-04-23T12:00:00Z",
+  "updatedAt": "2026-04-23T13:15:00Z",
+  "tasks": [
+    {
+      "task": "T1-gizmo-design",
+      "taskType": "gizmo",
+      "status": "completed",
+      "startedAt": "2026-04-23T12:02:00Z",
+      "endedAt": "2026-04-23T12:18:00Z",
+      "childSessionKey": "agent:main:subagent:1111-...",
+      "childCompletionEvent": true,
+      "artifactRef": "memory/ops/2026-04-23-s20.2-gizmo-design.md",
+      "attemptCount": 1,
+      "lastError": null,
+      "notes": null
+    },
+    {
+      "task": "T3-nutts-build-h3",
+      "taskType": "nutts",
+      "status": "spawned",
+      "startedAt": "2026-04-23T13:10:00Z",
+      "endedAt": null,
+      "childSessionKey": "agent:main:subagent:4e1f-...",
+      "childCompletionEvent": false,
+      "artifactRef": null,
+      "attemptCount": 1,
+      "lastError": null,
+      "notes": "H3 combined build: T1 schema + T2 Riv patch + T3 reconciler docs"
+    }
+  ]
+}
+```
+
+## See Also
+
+- `agents/riv.md` § Task-Ledger Protocol (S20.2 H3) — how Riv writes and reads this file.
+- `docs/active-arc-reconciler.md` — the watchdog that verifies arc artifacts independently.
+- `FRAMEWORK.md` § Core Principles #4 — "State lives in files, not in memory" (motivating principle).


### PR DESCRIPTION
## Sub-sprint: S20.2 (H3 — Riv-state durability)

Idempotency-key: sprint-20.2

## Scope (per arc brief §3 H3)
- Per-sub-sprint durable task-ledger (schema + state machine + atomic-write pattern)
- Riv profile ledger protocol + resume-declined handler + schemaVersion guard
- Active-arc reconciler `sprintShape` branching (build/spike/infra) — workspace-script patched separately; docs in this PR

## Changes
- `schemas/sprint-state-ledger.md` (new) — canonical ledger schema (schemaVersion: 1)
- `FRAMEWORK.md` — Workspace State subsection under Repo Structure referencing `memory/active-arcs.json` and `memory/sprint-state/<arc>/<sprint>.json`
- `agents/riv.md` — new "Task-Ledger Protocol (S20.2 H3)" section (when Riv writes, ledger-read on respawn, respawn decision table, atomic-write shell idiom, resume-declined handler + RIV-RESUME-DECLINED payload)
- `docs/active-arc-reconciler.md` (new) — reconciler docs + `sprintShape` field definition with full data contract + example

## Workspace-local side-effect
- `~/.openclaw/workspace/scripts/active-arc-reconciler.sh` patched with `sprintShape` branching (script is workspace-local, not in git)
- `sprintShape` defaults to `"build"` when absent (backward-compatible); `"spike"` uses workspace glob on `memory/ops/<N.M>-*.md`; `"infra"` uses same GitHub path as `"build"` (distinct taxonomy value)
- Smoke-ran post-patch: exit 0, JSON output valid, existing arcs resolve to `sprintShape: "build"` with no behavior change

## Acceptance (Optic will drill)
See Gizmo's 8 acceptance criteria — delegated to Optic.

## Source
- Arc brief: `memory/2026-04-23-arc-brief-hardening.md` §3 H3
- Gizmo design input: this sprint's Phase 1 output
- Ett sprint plan: this sprint's Phase 2 output