### PR TITLE
design(s21.2): UX polish bundle — #103 tooltips, #104 overlap, #107 first-encounter HUD

### DIFF
--- a/design/2026-04-23-s21.2-ux-bundle.md
+++ b/design/2026-04-23-s21.2-ux-bundle.md
@@ -1,0 +1,323 @@
+# S21.2 — UX Polish Bundle Design
+
+**Sprint:** S21.2
+**Issues:** brott-studio/battlebrotts-v2#103, #104, #107
+**Author:** Gizmo (Lead Designer)
+**Date:** 2026-04-23
+**Vision doc:** `docs/kb/ux-vision.md` (Eve from WALL-E pillars — professional, clean, polished, smooth curves, intentional color)
+**HCD ruling:** 2026-04-23T15:09Z, Q2 of arc brief — #107 mechanism is Gizmo's call under vision doc.
+
+## Context: prior S17.1 work
+
+Significant prior work landed in S17.1 on these exact issues. **S21.2 is a completion / extension pass, not greenfield.** Already shipped:
+
+- `S17.1-002` — Loadout footer overlap fix: `ScrollContainer` (`ScrollArea`) at `LoadoutScreen/ScrollArea`, footer buttons (back/equip) anchored as siblings outside the scroll. Tested at inv sizes 0/5/20/50.
+- `S17.1-003` — Visible-by-default tooltips on Loadout rows + Shop cards (inline summary labels, hover `tooltip_text` preserved as backup); Energy legend `Label` named `EnergyLegend` at `main.gd` arena root, anchored top-left under HUD.
+- `S17.1-004` — First-encounter HUD energy overlay using `FirstRunState` autoload (`user://first_run.cfg`, `[seen]` section), key `energy_explainer`, dismiss-on-input or tick-budget auto-dismiss.
+- `S17.1-006` — First-run crate framing in `trick_choice_modal.tscn` keyed `crate_first_run`.
+
+The `FirstRunState` autoload (`ui/first_run_state.gd`) is the canonical persistence pattern: `has_seen(key)` / `mark_seen(key)` / `reset(key)` against a flat `ConfigFile`. **All S21.2 first-encounter work reuses this — no new persistence layer.**
+
+What remains under each issue is genuine playtest follow-through, not duplicate work. Each section below explicitly delineates "already landed" vs "S21.2 scope."
+
+---
+
+## Issue #103 — Tooltips visible by default
+
+### Already landed (S17.1-003 — do NOT redo)
+
+- `LoadoutScreen` weapon/armor/module rows: inline summary label adjacent to name (no hover required).
+- `ShopScreen` cards: inline description label rendered under each item card.
+- `main.gd` arena: `EnergyLegend` Label visible by default below player HUD info.
+
+### S21.2 scope — critical-info tooltips still hover-only
+
+After S17.1-003, the following are still hover-only and were flagged by playtest:
+
+#### Critical-info tooltips → CONVERT to always-visible inline label
+
+| # | Screen | Node path (current) | What's hover-only today | Inline copy (BrottBrain voice, ≤8 words) |
+|---|---|---|---|---|
+| 1 | Brottbrain editor | `BrottbrainScreen/<TriggerButton tray cards>` (created in `_build_ui` ~line 215, `TRIGGER_DISPLAY[i]` buttons) | Trigger semantics (e.g. "When low HP" → fires under 30%) | Add small caption Label below each button row, font_size 9, color `Color(0.65,0.65,0.65)`, copy from `TRIGGER_DISPLAY[i][2]` (extend display tuple) |
+| 2 | Brottbrain editor | `BrottbrainScreen/<ActionButton tray cards>` (~line 240, `ACTION_DISPLAY[i]`) | Action effect (e.g. "Dash" → 3-tile rush, 20 energy) | Same pattern as #1 — caption Label below button, copy from `ACTION_DISPLAY[i][2]` |
+| 3 | Opponent select | `OpponentSelectScreen/<panel y+10> name_lbl` (~line 41) | Opponent threat tier / signature trick | Add inline subtitle Label at `(60, y+65)`, font_size 12, italic-equivalent (faded), one-sentence summary from `OpponentData.opponent_summary(league, idx)` (Nutts adds helper) |
+| 4 | Loadout | `LoadoutScreen/ScrollArea/Content/_weight_bar` | Weight cap meaning (current weight / max, what overload does) | Inline label "Weight: X/Y · over cap = slower turns" rendered to right of bar. Already has weight bar (line 203 `_weight_bar.max_value`); add adjacent Label. |
+| 5 | Brottbrain editor | `BrottbrainScreen/<stance_opt OptionButton>` (~line 105) | Stance effect (Aggressive/Balanced/Defensive — what it actually does) | Inline caption Label below the OptionButton at `(160, 90)` with current selection's effect; updates on `item_selected` signal. |
+| 6 | Result screen | `ResultScreen/<league progress block>` | What "Bronze 2/4" means, what unlocks at full progress | Single-line Label under league progress: "Win league to unlock Silver" (or current state) |
+
+**Total: 6 critical conversions.**
+
+#### Nice-to-have — hover-OK stays
+
+- Concede button (`game_main.gd:_create_arena_hud → ConcedeButton`) — destination is obvious from copy; hover is fine.
+- Speed multiplier label (`speed_label`) — already shows current value; hover for "1×/2×/4×" detail is fine.
+- Help button in `BrottbrainScreen` (`_build_ui` ~line 92, "?") — its whole purpose is to be tapped.
+- Shop "back" / "buy" / "sell" buttons — copy is self-explanatory.
+- Main menu buttons.
+
+#### Implementation note for Nutts
+
+- **Pattern:** the S17.1-003 pattern is canonical — add a sibling `Label` below/beside the parent control, set `font_size` 9–12 (smaller than the control's text), `font_color` to a muted grey `Color(0.65, 0.65, 0.65)` so the inline copy reads as supporting info not as a primary control. Preserve any existing `tooltip_text` (hover backup) — do not strip it.
+- **Copy source:** for #1 and #2, extend the existing `TRIGGER_DISPLAY` / `ACTION_DISPLAY` constants in `brottbrain_screen.gd` from 2-tuple `[icon, label]` to 3-tuple `[icon, label, summary]`. Keep summaries ≤8 words, present tense, BrottBrain voice.
+- **Layout impact:** caption labels add ~16 px height per row in the Brottbrain card tray. The tray is currently inside `BrottbrainScreen` at `tray_y` starting 370. Moving captions in pushes the back/Fight buttons (currently at y=650) into collision territory. **This is exactly issue #104 — see next section. Solve #104's mechanism first; #103 captions ride on top of #104's scroll fix.**
+- **Do NOT** add captions inside the arena combat HUD (would clutter against vision-doc anti-pattern "cluttered HUDs with 8+ simultaneous badges"). Arena tooltips are already minimal (energy legend only).
+
+#### Vision-doc alignment
+
+- ✅ Anti-pattern direct hit: vision doc explicitly lists `"Hover-only affordances (already flagged in playtest — tooltips must be visible by default)"` — this issue is the named anti-pattern.
+- ✅ Pillar **Clean**: inline copy in muted grey preserves typography hierarchy (control text is primary, summary is secondary).
+- ✅ Writing guidance: "Labels short. Tooltips one sentence." — caption budget capped at 8 words.
+- ⚠️ Pillar **Professional**: don't cram captions onto every control — the "nice-to-have" list above honors restraint. Inline copy where it answers a real question; hover stays for self-evident controls.
+
+---
+
+## Issue #104 — UI overlap fix at full inventory / loadout
+
+### Already landed (S17.1-002)
+
+- `LoadoutScreen` has `ScrollContainer` named `ScrollArea` at position `(0, 120)`, size `(1280, 520)`, vertical-only. Footer buttons (back/equip/continue) live as siblings outside the scroll, anchored to the bottom — they don't overlap regardless of inventory size.
+- Tested at inv = 0/5/20/50.
+
+### S21.2 scope — overlap is now elsewhere
+
+Playtest re-flagged overlap on screens that S17.1-002 didn't touch. Two screens are at risk; one is acute, one latent:
+
+#### Acute: `BrottbrainScreen` card tray collides with footer at high content density
+
+- **Node path:** `BrottbrainScreen/` (top-level Control). Internal layout uses **absolute pixel positions** with no scroll wrapper for the WHEN/THEN tray (`brottbrain_screen.gd` lines ~195–254).
+- **Failure mode:** the tray uses `tray_y += 28` row-wrap when `tx > 700`. With current trigger/action card counts plus the #103 inline captions (extra ~16 px per button), `tray_y` reaches ~620. Back button at `y=650`, Fight! button at `y=650`. **Collision at full content + captions = unreachable Fight button.**
+- **Already-scrolled:** the *behavior cards* region above (lines 140–157) has `card_scroll: ScrollContainer (770, 220)` from S17.4-002 — that part is fine.
+
+#### Latent: `OpponentSelectScreen` panels can overflow
+
+- **Node path:** `OpponentSelectScreen/`. Each opponent panel is `(700, 120)` placed at increasing `y`, with back button at `y=650`. With 4+ opponents per league (Bronze ships with 4; later leagues may have 5–6), `y` reaches `40 + 6*130 = 820`, well past the back button.
+- Today Bronze is exactly 4 opponents → `y = 40 + 4*130 = 560` — not yet overlapping but **one league expansion away from breaking**, and S21.2 #103 adds a subtitle Label per panel which inflates panel height to ~140, advancing the collision date.
+
+### Mechanism choice — wrap both with `ScrollContainer` (one mechanism, justified)
+
+**Decision: ScrollContainer wrapper, mirroring the S17.1-002 LoadoutScreen pattern.**
+
+Considered alternatives:
+- *Responsive spacing / dynamic shrinking* — fails the **Clean** pillar (typography compresses, hierarchy collapses) and produces inconsistent button hit-targets.
+- *Grid re-flow / pagination* — adds tap-to-navigate cost, overkill for content that fits 1.5× a viewport.
+- *Modal-ize the tray* — breaks the spatial-thinking model players have built around the editor.
+- ✅ *ScrollContainer wrapper* — matches S17.1-002 (consistency), preserves layout intent, footer anchors stay reachable, mobile/web both handle scroll natively.
+
+**One mechanism = one pattern** is deliberate: it lets Nutts adapt the same `ScrollContainer + sibling-anchored footer` recipe and lets Optic reuse the S17.1-002 fixture pattern.
+
+### Implementation note for Nutts
+
+#### `BrottbrainScreen` — wrap WHEN/THEN tray in scroll
+
+- Insert `ScrollContainer` named `TrayScroll` at position `(0, 365)` size `(1280, 280)`, vertical-only (`SCROLL_MODE_AUTO`), `horizontal_scroll_mode = SCROLL_MODE_DISABLED`, `follow_focus = true`.
+- Move tray content (`tray_hdr`, `WHEN:` row + trigger buttons, `THEN:` row + action buttons, *and #103 caption Labels*) into a `Control` content child of `TrayScroll`. Set `content.custom_minimum_size = Vector2(1260, computed_height)` where `computed_height` is sum of rows.
+- Footer buttons (back at `(20, 650)`, Fight! at `(1050, 650)`) stay siblings of `TrayScroll`, **not children**, so they always render outside the scroll.
+- Existing `card_scroll` (behavior cards) at `(20, 132)` is unchanged.
+
+#### `OpponentSelectScreen` — wrap opponent list in scroll
+
+- Insert `ScrollContainer` named `ListScroll` at position `(0, 60)` size `(1280, 580)` (header at top, back button at bottom — same pattern).
+- Move the for-loop opponent panels into a `Control` content child sized `Vector2(1260, 40 + count * 130)`.
+- Back button stays sibling at `(20, 650)`.
+
+#### Cross-screen audit (do NOT add scroll to these — verified safe)
+
+- `LoadoutScreen` — already done in S17.1-002. ✅
+- `ShopScreen` — has `ScrollArea` from S17.1-001. ✅
+- `MainMenuScreen` — small fixed content, no risk. ✅
+- `ResultScreen` — small fixed content. ✅
+- Combat HUD (`game_main.gd:_create_arena_hud`) — fixed positions, intentional spatial layout, scroll would break the gameplay surface. ✅ leave alone.
+
+### Vision-doc alignment
+
+- ✅ Anti-pattern direct hit: `"Overlapping UI elements that mask critical buttons (also flagged in playtest)"` — issue #104 is the named anti-pattern.
+- ✅ Pillar **Polished**: scroll behavior is smooth/native and `follow_focus` keeps keyboard/gamepad nav coherent.
+- ✅ Pillar **Clean**: footer-anchored CTAs preserve typography hierarchy regardless of content density.
+- ✅ Consistency with prior fix (S17.1-002 / S17.4-002 / S17.1-001) — three screens already use this pattern; adding two more reinforces a house style rather than introducing one.
+
+---
+
+## Issue #107 — First-encounter HUD explanations
+
+**HCD ruling (2026-04-23T15:09Z, Q2):** Gizmo's call under vision-doc pillars. Ruling not re-litigated.
+
+### Already landed (S17.1-004)
+
+- `FirstRunState` autoload (`ui/first_run_state.gd`) — flat `ConfigFile` at `user://first_run.cfg`, `[seen]` section, `has_seen(key)` / `mark_seen(key)` / `reset(key)` API. Reserved keys: `energy_explainer`, `crate_first_run`. **New keys require zero code change to the helper.**
+- `EnergyLegend` static Label visible by default in arena (`main.gd`).
+- `energy_explainer` first-encounter overlay: spawns on first arena entry if `!has_seen("energy_explainer")`, dismiss-on-input or tick-budget auto-dismiss, marks key seen on dismissal.
+
+### S21.2 scope — extend the pattern to the rest of the minimum HUD set
+
+The mechanism is already proven (S17.1-004). S21.2 extends it to 3 more elements and tightens the trigger semantics.
+
+### Mechanism choice — **inline first-encounter callout overlay, anchored to the explained element, dismiss-on-tap or tick-budget**
+
+This is the same pattern as S17.1-004's `_spawn_energy_explainer`, generalized.
+
+#### Why this mechanism (not the other options)
+
+| Option | Verdict | Reason against |
+|---|---|---|
+| (a) One-time tooltip overlay on first run, implicit dismiss | **CHOSEN** (extension of S17.1-004) | Matches Eve: a calm pointer that fades, not a popup that demands input. Already have the persistence + overlay scaffolding; extending it is the lowest-risk path. |
+| (b) Inline label fade on first arena entry | Rejected as primary | Anti-pattern risk: per vision-doc "Cluttered HUDs with 8+ simultaneous badges/numbers." Multiple inline labels firing simultaneously on first entry = visual stampede. |
+| (c) Dedicated info screen from menu | Rejected as primary | Anti-pattern: vision-doc warns "Popup spam … that interrupt flow." A modal info screen *is* an interruption. Acceptable as a *secondary* affordance, not the primary mechanism. |
+| (d) Combo: ship (a) + reach-from-menu (c) as secondary | **Future, not S21.2** | Logical extension once (a) is generalized; out of scope for this sub-sprint to keep #107 inside its budget. |
+
+**Eve pillar mapping for the chosen mechanism:**
+
+- **Professional** — overlay is a quiet pointer + ≤14-word caption, no exclamation, no "Welcome to BattleBrotts!" greeting. Matches Eve's restrained voice.
+- **Clean** — one element explained at a time; overlay dimmed background (alpha 0.4), single rounded panel, single sentence.
+- **Polished** — fade in/out (≥150 ms ease-out), tick-budget auto-dismiss prevents a missed-tap from stalling the player. Non-blocking: combat sim continues underneath at 0.25× speed (already implemented in S17.1-004 — confirmed pattern).
+- **Smooth curves** — overlay panel uses rounded corners (`StyleBoxFlat.corner_radius_*` = 8 px, matching S17.1-004 style).
+- **Intentional color** — overlay accent uses the *element's own color* (energy = the energy bar's hue) to bind the explanation to the thing being explained. No new color introduced.
+
+### Minimum HUD set — energy bar + 3 others
+
+Selected from current `game_main.gd:_create_arena_hud` and `arena/arena_renderer.gd` HUD elements. Total = 4. Each gets a `FirstRunState` key.
+
+| # | HUD element | Where | First-encounter copy (≤14 words) | `FirstRunState` key |
+|---|---|---|---|---|
+| 1 | **Energy bar** (above each Brott) | `arena_renderer.gd:894` (`b.energy / 100.0`) | *(already shipped — keep S17.1-004 wording)* — "Energy fuels actions. Refills over time. Manage it like a pro." | `energy_explainer` *(existing)* |
+| 2 | **Player / enemy info labels** (HP + status) | `game_main.gd` `player_info` / `enemy_info` Labels at top corners | "Your Brott (left) vs the opponent (right). Watch HP — first to zero loses." | `combatants_explainer` |
+| 3 | **Time label** (match clock) | `game_main.gd` `time_label` top-center | "Match clock. Most fights end before this hits zero." | `time_explainer` |
+| 4 | **Concede button** | `game_main.gd` `ConcedeButton` top-right | "Throwing in the wrench forfeits the match. Two-step confirm." | `concede_explainer` |
+
+**Speed multiplier label** is intentionally omitted — its function is obvious (1× / 2× / 4×) and adding a callout for it would push toward the "8+ simultaneous badges" anti-pattern.
+
+### First-encounter trigger semantics
+
+**Trigger surface = first arena entry per fresh save**, sequenced one-per-arena-entry to avoid stampede.
+
+- On entering arena (`_start_match` in `game_main.gd`), check `FirstRunState` keys in fixed priority order: `energy_explainer` → `combatants_explainer` → `time_explainer` → `concede_explainer`.
+- Spawn the **first one in the list whose key is not yet seen.** Only one overlay per arena entry, max.
+- Sequence ensures: first match = energy. Second match = combatants. Third = time. Fourth = concede. By match 5, all explainers are dismissed and the arena is silent.
+- Tick-budget auto-dismiss (existing S17.1-004 const `ENERGY_EXPLAINER_TICK_BUDGET`) generalized to a per-overlay budget — start at the same value (~720 ticks ≈ 12 sim-seconds at 1× speed).
+
+**Why one-per-match (not all-at-once on match #1):**
+
+- Vision-doc anti-pattern: "Cluttered HUDs … Popup spam." Stacking 4 overlays = exactly that.
+- Matches Eve: she doesn't lecture; she points at one thing.
+- Pragmatic: the first match is a player's first combat experience — a single explainer (energy) lets them watch the actual fight, the most important onboarding signal of all.
+
+### Persistence — reuses S17.1-004 pattern
+
+- `FirstRunState` autoload, no schema change.
+- Add 3 keys to the reserved-list comment in `ui/first_run_state.gd`:
+  - `combatants_explainer` (S21.2-002)
+  - `time_explainer` (S21.2-002)
+  - `concede_explainer` (S21.2-002)
+- Survives session restart (writes to `user://first_run.cfg` on `mark_seen`).
+- Fresh saves (no file present) → all keys default `false` → all 4 overlays will fire across the first 4 arena entries.
+
+### Implementation note for Nutts
+
+- **Refactor `main.gd:_spawn_energy_explainer` into a generic `_spawn_first_encounter_overlay(key, anchor_node, copy)` helper.** The S17.1-004 implementation is already 80% there — extract the panel construction (panel + Label + dismiss button + tick-budget setup) into a parameterized function. Anchor target controls overlay position (call out the element being explained).
+- **Anchor positioning:** for each HUD element, the overlay should appear adjacent to the element, with a small ▲ pointer (3 px triangle from `StyleBoxFlat`) pointing back at it. Default anchor: ~40 px to the right or below the target. Clamp to viewport to avoid off-screen.
+- **Sequencing:** add `FIRST_ENCOUNTER_SEQUENCE: Array[Dictionary]` constant in `main.gd` listing the 4 keys + their target node accessor + their copy. Iterate at arena entry; spawn the first un-seen one.
+- **Sim slowdown:** S17.1-004 already slows sim to 0.25× while overlay is up. Generalize this to apply to any first-encounter overlay via the same hook.
+- **Fresh-save dev affordance:** keep the existing `FirstRunState.reset(key)` API (already present, dev-only). Optic uses it to test fresh-save state.
+- **Order of operations vs #103/#104:** this issue layers cleanly on top — overlays render at a higher z than the captions (#103) and outside any scroll wrappers (#104). No coupling.
+
+### Vision-doc alignment
+
+- ✅ Pillar **Professional**: copy is calm, one sentence, present tense, BrottBrain voice. No "🎉 Welcome!" or exclamation.
+- ✅ Pillar **Clean**: one element explained at a time; overlay is a single panel.
+- ✅ Pillar **Polished**: fade transitions, tick-budget auto-dismiss, sim continues underneath at reduced speed.
+- ✅ Pillar **Smooth curves**: rounded panel corners (consistent with S17.1-004).
+- ✅ Pillar **Intentional color**: overlay accent uses the explained element's own color, no palette expansion.
+- ✅ Anti-pattern avoided: not "popup spam" — sequenced one-per-match, dismiss-once-and-done.
+- ✅ Anti-pattern avoided: not "cluttered HUDs" — overlay is dismissable and disappears permanently after first encounter.
+- ✅ Checklist line: "Energy bar (and every HUD element) has in-game explanation on first encounter" — directly satisfied for the minimum HUD set; speed label omitted by design (justified above).
+
+---
+
+## Acceptance hooks for Optic
+
+Per arc brief §5 S21.2 acceptance criteria. Three test groups, fixture-driven.
+
+### #103 — Visible-by-default tooltips
+
+**Fixture state:** standard mid-game save (Bronze league, ~5 weapons / 3 armor / 2 modules in inventory, brain editor open with 4 behavior cards).
+
+- `test_s21.2_001_brottbrain_caption_visible` — render `BrottbrainScreen`, assert each trigger button (`TRIGGER_DISPLAY[i]` row) has a sibling Label child at expected y-offset, font_size ≤ 12, color ≈ muted grey, copy matches `TRIGGER_DISPLAY[i][2]`. Same for action buttons.
+- `test_s21.2_001_opponent_subtitle_visible` — render `OpponentSelectScreen` with Bronze fixture; assert each opponent panel has subtitle Label at `(60, y+65)`, copy non-empty.
+- `test_s21.2_001_loadout_weight_caption` — render `LoadoutScreen`; assert `_weight_bar` has adjacent Label with format "Weight: X/Y · over cap = slower turns".
+- `test_s21.2_001_stance_caption_updates_on_change` — render Brottbrain, change stance via `OptionButton.select(...)`; assert caption Label text reflects new selection.
+- `test_s21.2_001_result_progress_caption` — render `ResultScreen` with mid-league fixture; assert progress block has caption Label.
+- **Playwright snapshot:** capture a baseline screenshot per affected screen at this fixture state and verify "no hover required to surface critical info" — visual diff against approved baseline. (Optic produces baselines on first run; subsequent runs assert pixel diff.)
+
+### #104 — UI overlap fix
+
+**Fixture states:** (a) full inventory (50 items, brain at 8 cards) and (b) max league with 6 opponents.
+
+- `test_s21.2_002_brottbrain_no_overlap_full` — fixture: brain editor with all visible triggers + actions. Assert `BrottbrainScreen/TrayScroll` exists, has expected size, has scroll content larger than viewport. Assert back button + Fight button both reachable (`get_global_rect()` not intersecting any tray child rect).
+- `test_s21.2_002_opponent_select_no_overlap_max` — fixture: synthetic 6-opponent league. Assert `OpponentSelectScreen/ListScroll` exists; back button reachable; all 6 panels accessible via scroll.
+- `test_s21.2_002_brottbrain_signal_contract_preserved` — assert `back_pressed` and `continue_pressed` signals still emit from the post-refactor footer buttons.
+- `test_s21.2_002_opponent_signal_contract_preserved` — assert opponent-select signal still emits the chosen index.
+- `test_s21.2_002_empty_states_unchanged` — fixture: 0 cards / 0 opponents (degenerate). Assert no awkward gap, no scroll where none needed (matches S17.1-002 AC-6).
+- **Playwright snapshot:** screenshot at max-capacity fixture, verify all critical buttons unmasked.
+
+### #107 — First-encounter HUD explanations
+
+**Fixture states:** (a) fresh save (no `user://first_run.cfg` present) and (b) post-first-encounter save (4 keys all marked seen).
+
+- `test_s21.2_003_fresh_save_first_overlay_is_energy` — fresh-save fixture, enter arena via `_start_match`. Assert overlay spawns. Assert overlay key = `energy_explainer`. Assert sim is throttled.
+- `test_s21.2_003_sequence_advances_per_arena_entry` — fresh save → enter arena, dismiss overlay, leave; enter again. Assert overlay key = `combatants_explainer`. Repeat for `time_explainer` and `concede_explainer`.
+- `test_s21.2_003_no_overlay_after_all_seen` — fixture: all 4 keys marked seen. Enter arena. Assert no overlay spawned, no sim throttle.
+- `test_s21.2_003_input_dismisses_and_persists` — fresh save, spawn overlay, simulate dismiss-tap. Assert overlay removed. Assert `FirstRunState.has_seen(key)` returns `true`. Re-enter arena → next key in sequence fires.
+- `test_s21.2_003_tick_budget_dismisses_and_persists` — fresh save, spawn overlay, advance `ENERGY_EXPLAINER_TICK_BUDGET` ticks without input. Assert overlay auto-dismisses. Assert key marked seen.
+- `test_s21.2_003_first_run_state_api_unchanged` — sanity: assert `FirstRunState` autoload still exposes `has_seen` / `mark_seen` / `reset` with same signatures (regression guard against accidental refactor of the helper).
+- `test_s21.2_003_legend_identity_preserved` — assert S17.1-004 `EnergyLegend` Label still exists and has same text/anchor (regression guard).
+- **Playwright snapshot:** fresh-save, first arena entry, capture overlay visual; assert against baseline (covers visual styling: rounded corners, dim background, anchor pointer).
+
+### Cross-cutting
+
+- `test_s21.2_004_no_console_errors` — render each affected screen, assert zero `push_error` / `push_warning` to stderr (catches missing nodes after refactor).
+- **Optic fresh-save fixture pattern:** call `FirstRunState.reset(key)` for each of the 4 keys + remove `user://first_run.cfg` before tests in group #107. Pattern already used by `test_sprint17_1_first_encounter_hud.gd:_cleanup_store()`.
+
+---
+
+## Open scope concerns / split escape hatch
+
+**Ett's pre-noted split:** if #107 mechanism inflates beyond a polish item, split S21.2a (#103+#104) → S21.2b (#107 as S21.3).
+
+### Gizmo's recommendation: **DO NOT SPLIT.**
+
+Rationale:
+
+1. **#107 mechanism is not new system work.** S17.1-004 already shipped the entire scaffolding: `FirstRunState` autoload, energy overlay panel, dismiss-on-input, tick-budget auto-dismiss, sim slowdown. S21.2's #107 work is a 4-line refactor of `_spawn_energy_explainer` into a parameterized helper, plus 3 new copy strings + 3 new keys. **This is polish, not a system.**
+2. **Coupling with #103 is favorable.** #103 caption labels add height to the Brottbrain tray, which forces #104's scroll wrapper, which makes the whole tray-area refactor contiguous. Splitting #107 out doesn't change this; coupling stays inside S21.2.
+3. **Estimate:** Nutts implementation budget ≈ #103 (4–6 h) + #104 (3–5 h) + #107 (2–3 h) = 9–14 h total. Within a single sub-sprint envelope. No split required.
+4. **If reality diverges:** Ett's escape hatch remains valid — if Nutts hits an unforeseen blocker on #107 (e.g., the generic overlay helper turns out to need significant z-order or input-routing rework), invoke split mid-sub-sprint. The design above is structured so #103+#104 land independently of #107 (no cross-issue dependencies in the implementation order).
+
+### Recommended Nutts implementation order
+
+1. **Issue #104 first** — wrap `BrottbrainScreen` tray + `OpponentSelectScreen` list in `ScrollContainer`. Lands the structural refactor before adding content.
+2. **Issue #103 second** — add inline captions, riding inside the new scrolls. Verifies #104 actually solves the overlap once captions inflate row heights.
+3. **Issue #107 last** — refactor energy explainer to generic helper, add 3 new keys + sequence logic. Independent of #103/#104 surface area.
+
+If Nutts hits trouble, this order also gives the cleanest split point: stop after step 2, ship #103+#104, defer #107 to S21.3.
+
+---
+
+## Vision-doc citation summary (per arc-brief §9 risk #5)
+
+Every decision above traces to `docs/kb/ux-vision.md`:
+
+- **#103 mechanism** ← Anti-pattern line: `"Hover-only affordances (already flagged in playtest — tooltips must be visible by default)"` + Pillar **Clean** (typography hierarchy preserved by muted secondary labels) + Writing guidance (`"Labels short. Tooltips one sentence."`).
+- **#104 mechanism (ScrollContainer)** ← Anti-pattern line: `"Overlapping UI elements that mask critical buttons (also flagged in playtest)"` + Pillar **Polished** (smooth/native scroll) + consistency with existing landed pattern (S17.1-002 cited the same).
+- **#107 mechanism (sequenced first-encounter overlay)** ← Pillars **Professional** (calm, single sentence), **Clean** (one-at-a-time), **Polished** (fade + tick-budget), **Smooth curves** (rounded panel), **Intentional color** (element-color accent) + Anti-patterns avoided: `"Cluttered HUDs with 8+ simultaneous badges/numbers"` and `"Popup spam (random events, crate/trade prompts) that interrupt flow"` + Checklist line: `"Energy bar (and every HUD element) has in-game explanation on first encounter"`.
+
+---
+
+## Out of scope for S21.2 (do NOT fold in)
+
+Per arc-brief §9 risk #3 ("UX fix scope creep"):
+
+- Tooltip *content quality* beyond the 6 critical conversions above — file as new backlog issues if playtest flags specific copy.
+- Random-event popup redesign (vision-doc checklist line, but separate playtest flag — out of scope for S21.2; if HCD wants it, file as S21.4).
+- League-progression-path surfacing (vision-doc checklist line, separate concern).
+- Motion-curve easing audit (vision-doc checklist line, separate concern).
+- Audio (S21.3 owns all audio scope).
+- Combat-screen content changes (Nutts implementation only — no new combat affordances introduced by this design).


### PR DESCRIPTION
Gizmo design doc for **S21.2 — UX polish bundle** (Arc B: Content & Feel).

Closes (design-side) battlebrotts-v2#103, battlebrotts-v2#104, battlebrotts-v2#107 (Nutts implements next).

**HCD ruling:** 2026-04-23T15:09Z, Q2 — #107 mechanism is Gizmo's call under `docs/kb/ux-vision.md` Eve-from-WALL-E pillars. Mechanism chosen + justified in §107.

**Decisions:**
- #103 — 6 critical-info inline captions, hover stays for self-evident controls
- #104 — ScrollContainer wrapper for BrottbrainScreen tray + OpponentSelectScreen list (mirrors S17.1-002 pattern)
- #107 — sequenced first-encounter overlay extending S17.1-004 energy explainer; min HUD set = energy + combatants + clock + concede

**Split escape hatch:** Gizmo recommends NOT splitting (S21.2a/b unused). #107 is a parameterized refactor of existing scaffolding, not new system work.

**Vision-doc alignment:** every decision cited against `docs/kb/ux-vision.md` per arc-brief §9 risk #5.

Doc: `design/2026-04-23-s21.2-ux-bundle.md` (323 lines).