### PR TITLE
policy: expand model-substitution rule — Gizmo on Sonnet 4.6 for long-write deliverables

### DIFF
--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -85,6 +85,24 @@ Riv's final report to The Bott fires on **arc-complete**, not on audit-commit.
 | 🕵️ **Specc** | Inspector | Audits, learning extraction, KB |
 | 🔧 **Patch** | DevOps | Infrastructure (on-demand) |
 
+## Model Assignments (standing rules)
+
+Model substitution policy — derived from Arc B S21.2 (2026-04-23) + Arc D S23.1 + Arc E framing (2026-04-24):
+
+| Role | Default model | Rationale |
+|---|---|---|
+| **Nutts** | Sonnet 4.6 | Opus 4.7 truncation pattern on long-write code emits (S21.1, S21.2). |
+| **Optic** | Sonnet 4.6 | Same class of output (long-write verification reports). |
+| **Specc** | Sonnet 4.6 | Same class (long-write audit docs). |
+| **Gizmo — long-write deliverables** (arc briefs, specs >1200 words with embedded multi-file reads) | Sonnet 4.6 | Opus 4.7 truncation on tool-call-during-emit pattern (Arc E framing 2026-04-24: two 30min/0-token timeouts on Opus; Sonnet completed in 2m21s). |
+| **Gizmo — short framings** (sub-sprint framings, <800 words, few reads) | Opus 4.7 | No evidence of pattern at this size/shape. |
+| **Ett** | Opus 4.7 | Planning work; no evidence of pattern (S23.4, S23.5 ran clean). |
+| **Boltz** | Opus 4.7 | Review work; no evidence of pattern. |
+| **Riv** | Opus 4.7 | Orchestration; no evidence of pattern. |
+| **The Bott (main session)** | Opus 4.7 | HCD-interface; no evidence of pattern at this role's output shape. |
+
+**Re-entry criteria for restoring Opus 4.7 to Sonnet-4.6-assigned roles:** 30 consecutive days of clean runs on Opus 4.7 across all pipeline roles under the expanded policy. Tracked via `battlebrotts-v2#246` + `studio-framework#57`.
+
 ## Repos
 
 | Repo | Purpose | Who Writes |

--- a/agents/the-bott.md
+++ b/agents/the-bott.md
@@ -107,6 +107,8 @@ When unsure, err toward handling directly and note the choice rather than spawni
 
 ## Canonical spawn discipline (HARD RULE)
 
+**Model selection per role:** see `PIPELINE.md` §Model Assignments. Summary: Nutts/Optic/Specc on Sonnet 4.6; Gizmo on Sonnet 4.6 **only for long-write deliverables** (arc briefs, specs >1200 words with embedded multi-file reads); Ett/Boltz/Riv/short-Gizmo on Opus 4.7. When spawning, set `model` explicitly based on the role’s output shape — don't rely on defaults.
+
 **Never hand-roll stop conditions or scope overrides in a Riv (or other pipeline-agent) task prompt.** Spawn with the canonical inputs only:
 - Arc brief pointer (`sprints/sprint-<N>.md` or `arcs/arc-<N>.md`)
 - Current sprint plan pointer (or "next sprint TBD; Ett to plan")


### PR DESCRIPTION
Formalizes the policy expansion triggered by Arc E framing today (2026-04-24T17:15Z). See PIPELINE.md §Model Assignments.

Context: Arc D S23.1 closed the Opus 4.7 truncation investigation as no-repro with an explicit caveat that tool-call-during-emit stimulus shape was not exercised. That caveat fired empirically within 2h on Arc E framing — two Gizmo/Opus-4.7 spawns timed out at 30min/0-tokens-out on a ~2000-word arc brief with 4 embedded file reads. Sonnet 4.6 completed the same task in 2m21s.

Narrow expansion: Gizmo on long-write deliverables → Sonnet 4.6. Other Opus 4.7 roles (Ett/Boltz/Riv/short-Gizmo) continue as-is — no evidence of the pattern on those shapes today.

Related:
- battlebrotts-v2#246 (re-opened with status:mitigated-with-expanded-scope)
- studio-framework#57 (re-opened with expanded mitigation)

Re-entry criteria: 30 days clean on Opus 4.7 across all pipeline roles.