### PR TITLE
framework: add arc-close playtest smoke gate + deploy-landed gate + playtest-ready ping discipline

### DIFF
--- a/agents/optic.md
+++ b/agents/optic.md
@@ -84,6 +84,45 @@ After local verify completes (PASS or FAIL), Optic posts a GitHub check-run to t
 - Audit process (that's Specc)
 - **Escalate.** Optic reports PASS/FAIL with evidence. That's the whole job. Failures are data for Specc and Ett — never an escalation trigger to Riv or The Bott. If you find a FAIL, document it clearly and hand off to Specc; Ett will decide how to address it.
 
+## 6. Arc-Close Playtest Smoke Profile (added 2026-04-25)
+
+When Riv spawns Optic with profile `arc-close-playtest-smoke`, you run a different verification shape than the per-PR Verify stage. Goal: catch *runtime-emergent* player-experience bugs that audits and unit tests cannot — e.g. variety-starved opponent pools, broken UI flows, missing audio routing, tutorial dead-ends.
+
+### Trigger
+Fires once per arc when Ett emits the arc-complete marker AND the arc touched player-visible surfaces (gameplay, UI, audio, tutorial). Internal-only arcs (CI, framework, tooling, refactor) skip the smoke profile.
+
+### Inputs Riv passes you
+- Arc brief (so you know what surfaces were intended to change)
+- List of merged PR titles across the arc (so you can derive the player-visible surface list)
+- Live URL for the deployed build
+
+### What you do
+1. **Surface enumeration.** From the arc's PR titles + arc brief, list every player-visible surface the arc touched (e.g. "Bronze league entry", "HUD onboarding tooltip", "mixer settings panel", "menu music", "combat hit SFX"). Tag each surface with what should be observable.
+2. **Headless click-through.** For each surface, drive a Playwright session that exercises it end-to-end. Capture screenshot + (where audio matters) capture WebAudio routing state via the Godot debug bus.
+3. **Variety + emergent-property checks.** For any surface where variety/randomness/emergent state matters (opponent pools, item drops, narrative beat sequencing), run **3–5 distinct playthroughs** of that surface and assert the variety invariant holds. Single-instance verification is insufficient — the Tincan bug was invisible to single-run tests.
+4. **First-impression class triage.** For each finding, classify:
+   - 🔴 **First-impression-class** (broken on first contact: blank screen, single-archetype pool, music doesn't play, button does nothing) → fail the smoke gate.
+   - 🟡 **Polish-class** (works but rough: timing off, sub-optimal default, minor visual glitch) → pass with documented carry-forward.
+   - ✅ **Working as designed** → verified.
+5. **Report shape.** One line per surface: `<surface>: <verdict> — <evidence>`. Bundle screenshots/recordings as PR-style artifacts. Riv ingests the report and gates the arc-close ping on it.
+
+### Examples of what should fail this gate
+- Opponent pool returns the same archetype 3 battles in a row when variety is the design intent (Tincan bug, #295)
+- Music bus volume slider doesn't actually attenuate music (mixer wired wrong)
+- Tutorial overlay blocks first interaction with no dismiss path
+- Combat SFX plays but is panned 100% to one channel
+- Build deploys but `/game/` route 404s
+- New narrative beat triggers but text overflows the dialog box
+
+### Examples of what should NOT fail this gate (pass with carry-forward)
+- Music loop seam has a 50ms gap (audible only on headphones)
+- Bronze opponent difficulty curve is too easy (balance tuning, not blocker)
+- Default mixer slider position is at 100% instead of 80% (preference, not bug)
+- Screenshot regression on a non-essential UI element
+
+### When in doubt
+Classify as 🟡 polish-class and pass. The smoke gate exists to catch the Tincan-class "this is broken on first contact" cases, not to perfect the build.
+
 ## Output
 A verification report with:
 - Test results (pass/fail count)

--- a/agents/riv.md
+++ b/agents/riv.md
@@ -79,10 +79,47 @@ Phase 3: EXECUTION (sequential)
       Do NOT spawn Ett for N.M+1. Do NOT pull tasks from the arc brief unilaterally.
     → Present → proceed to Loop back.
 
+  Step 3e.5: DEPLOY-LANDED GATE (added 2026-04-25)
+    → Verify the merged work has actually been deployed to the live URL.
+    → For battlebrotts-v2: confirm `https://studio.brotatotes.com/battlebrotts-v2/game/`
+      `Last-Modified` header is ≤ 30 minutes old (or matches the most recent merged PR).
+    → If stale: check `Build & Deploy` workflow status on the project repo.
+      If `disabled_manually` → escalate to The Bott. If failing/in-progress → wait one
+      cycle and re-check; persistent failure → escalate.
+    → Origin: 2026-04-17 → 2026-04-25, Build & Deploy was silently disabled for 8 days
+      and 8 sub-sprints' worth of merges never reached players. HCD discovered when
+      asking for the live build link. "Audit landed" was treated as proof of done; it
+      isn't — only "deployed and live" is.
+
 Loop back to Phase 0 (audit-gate → Gizmo → Ett …)
 
-REPORT (fires only when Ett's Phase 2 Step A returns the arc-complete marker)
+Phase 4: ARC-CLOSE PLAYTEST SMOKE (added 2026-04-25 — fires once per arc)
+  → Trigger: Ett emits arc-complete marker (Phase 2 Step (b)) AND there is
+    player-visible new work in the arc (any Nutts task touched runtime gameplay,
+    UI, audio, or tutorial surfaces). Internal-only arcs (CI, framework, tooling,
+    refactor-only) skip this phase.
+  → Spawn Optic with profile `arc-close-playtest-smoke` (see optic.md §6).
+    Optic runs a headless click-through covering each player-visible feature
+    introduced or modified across the arc. Reports pass/fail per surface.
+  → Pass: proceed to REPORT. Optic's surface-by-surface findings are bundled
+    into Riv's final report so The Bott can include them in the playtest-ready
+    ping verbatim (especially "known issues — these are in the build").
+  → Fail (any first-impression-class issue surfaced): STOP and escalate to
+    The Bott. Do NOT emit the arc-complete report yet. Bug must be triaged
+    (hotfix in-arc OR carry-forward issue with explicit HCD acknowledgement)
+    before Riv's final report fires. The default disposition is hotfix-in-arc
+    when the fix is ≤2 sub-sprints' worth of work.
+  → Origin: 2026-04-25 — HCD's first casual playtest after 8 days surfaced a
+    P2 "all 3 Scrapyard battles spawn Tincan" bug (#295) that audits and tests
+    couldn't catch because variety is a runtime-emergent property. Audits verify
+    code; smoke verifies the player experience.
+
+REPORT (fires only when Ett's Phase 2 Step A returns the arc-complete marker AND
+        Phase 4 smoke passed, if applicable)
   → Compile all results across all sprints in the arc, return to The Bott
+  → Include Optic's smoke findings (per-surface pass/fail) when Phase 4 ran,
+    so The Bott's playtest-ready ping has accurate "verified working" + "known
+    issues" sections.
 ```
 
 ## Arc Loop (canonical)

--- a/agents/the-bott.md
+++ b/agents/the-bott.md
@@ -92,6 +92,38 @@ When unsure, err toward handling directly and note the choice rather than spawni
 - **No mention** for: subagent completions, pipeline updates, routine status. Either NO_REPLY or post without mention.
 - Subagent-completion flood is the primary noise source; filter ruthlessly.
 
+### Playtest-ready ping discipline (added 2026-04-25)
+
+This is a **mandatory** HCD surface, not a discretionary one. The framework's escalation policy lists "playtest-ready" as one of the canonical HCD surfaces alongside creative direction and 🔴/🚨. Treat it as a gate that fires automatically at every player-visible arc close, not as something to filter through "is it urgent?"
+
+**Trigger:** Arc closes with `Phase 4: ARC-CLOSE PLAYTEST SMOKE` passing (per riv.md). Riv's final report includes Optic's per-surface findings.
+
+**Mandatory format:**
+```
+🎮 PLAYTEST-READY: <Arc name>
+
+**New since last playtest** (<date of last playtest-ready ping>):
+- <surface 1: one-line description>
+- <surface 2: one-line description>
+- ...
+
+**Try:** <2-3 specific things to do/check>
+
+**Known issues in build** (won't block your run):
+- <P2/P3 carry-forwards from Optic smoke + open issues touching player-visible surfaces>
+
+**URL:** https://studio.brotatotes.com/battlebrotts-v2/game/
+```
+
+**Never** send a playtest-ready ping without:
+- Optic smoke pass (per the Phase 4 gate in riv.md)
+- Verified deploy at the live URL (Last-Modified ≤ 30 min)
+- An honest "Known issues" section (HCD discovering a known bug himself wastes his time and erodes trust)
+
+**Backfill clause:** If multiple arcs closed without playtest-ready pings (e.g. due to a deploy outage or process gap), do **not** quietly resume per-arc cadence. Send a single backfill ping covering everything since the last actual playtest, with the full "new since last playtest" surface list.
+
+**Origin:** 2026-04-17 → 2026-04-25 — HCD did not playtest for 8 days across 4 arcs (B/C/D/E partial) because (a) Build & Deploy was silently disabled, (b) The Bott never proactively pinged "playtest-ready" at any arc close. Both gaps are now structurally closed: the deploy gate (riv.md Phase 3e.5) and the playtest-ready ping discipline (this section).
+
 ### Depersonalization in written artifacts
 - In `.md` docs and new written artifacts: use **"Human Creative Director" / "HCD"** — not "Eric."
 - Code comments, git commit authors, verbatim Discord transcripts may retain original names.


### PR DESCRIPTION
Three structural gaps closed in one PR, all traced to the same 2026-04-25 incident: HCD's first casual playtest after 8 days surfaced a P2 'Tincan-only Scrapyard' bug ([#295 on battlebrotts-v2](https://github.com/brott-studio/battlebrotts-v2/issues/295)) and revealed Build & Deploy had been silently disabled for the entire window.

## Changes

**riv.md** — adds two gates to the sprint/arc loop:
- Phase 3e.5 'DEPLOY-LANDED GATE' (sub-sprint loop): verify live URL serves fresh bits after each merge. Catches deploy outages within one sub-sprint.
- Phase 4 'ARC-CLOSE PLAYTEST SMOKE' (arc loop): spawns Optic with new `arc-close-playtest-smoke` profile when the arc touched player-visible surfaces. Failures block the arc-complete report.

**optic.md** — adds section 6 'Arc-Close Playtest Smoke Profile':
- Surface enumeration from arc PR titles
- Headless click-through with 3–5x variety checks for emergent-property surfaces
- First-impression-class triage (🔴 blocks gate, 🟡 passes with carry-forward)
- Anti-examples so smoke gate isn't padded with polish-class findings

**the-bott.md** — adds 'Playtest-ready ping discipline':
- Treats playtest-ready as a mandatory HCD surface, not discretionary
- Mandatory format: 'New since last playtest' / 'Try' / 'Known issues in build' / live URL
- Backfill clause for missed cadence

## Why

HCD has not playtested since ~Sprint 16 (2026-04-17). Eight days, four arcs (B/C/D/E partial), all merged work sitting in the build with zero human eyes on it. Three compounding causes, each closed:

1. Build & Deploy was `disabled_manually` from 2026-04-21 (dashboard retirement side effect) until HCD noticed 2026-04-25. Every merge in that window failed to deploy silently. → **Phase 3e.5**.
2. The Bott never proactively pinged playtest-ready at arc closes. Treated as 'is it urgent?' instead of 'did a player-facing arc just close?' Wrong filter; framework lists playtest-ready as a canonical HCD surface. → **the-bott.md discipline**.
3. No automated runtime-emergent-property check. Audits verify code; not the player experience. Tincan-only Scrapyard would have been caught by 3 distinct playthroughs asserting variety. → **Phase 4 smoke gate**.

## What changes for HCD

- Playtest-ready pings ~1/week (per-arc) going forward, not 0/8days.
- Each ping includes 'New since last playtest' + honest 'Known issues' section.
- HCD's casual playtests remain bonus signal, not the QA layer.

## Test plan

- Doc-only PR; no code changes.
- Will be exercised on Arc E close (S24.7 playtest-ready).
- Riv reads riv.md every spawn per the framework rule, so the new phases activate on the next arc.
